### PR TITLE
Restore output file compression

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -15,7 +15,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         rust:
           - stable
-          - 1.43.0
+          - 1.51.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -47,7 +47,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         rust:
           - stable
-          - 1.43.0
+          - 1.51.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -15,7 +15,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         rust:
           - stable
-          - 1.51.0
+          - 1.53.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -47,7 +47,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         rust:
           - stable
-          - 1.51.0
+          - 1.53.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 code_coverage_report.sh
 data
 benchmark
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Support for LZMA, Bzip, and Gzip output compression (thanks to
+  [`niffler`](https://github.com/luizirber/niffler/)). This is either inferred from the
+  file extension or manually via the `-O` option.
+- Option to specify the compression level for the output via `-l`
+
 ### Changed
+
 - Use a `Vec<bool>` instead of `HashSet` to store the indices of reads to keep. This
   gives a nice little speedup (see [#28][28]), A big thank you to
   [@natir](https://github.com/natir) for this.
 
+### Fixed
+- Restore compression of output files [[#27][27]]
+
 ## [0.4.2]
 
 ### Fixed
+
 - I had stupidly forgetten to merge the fix for [#22][22] onto master 🤦
 
 ## [0.4.1]
 
 ### Fixes
+
 - Releasing cross-compiled binaries didn't work for version 0.4.0
 - Docker image is now correctly built
 
@@ -27,7 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Switch from using `snafu` and `failure` for error handling to `anyhow` and `thiserror`. Based on the procedure outlined in [this excellent blog post][error-blog].
+- Switch from using `snafu` and `failure` for error handling to `anyhow` and
+  `thiserror`. Based on the procedure outlined in [this excellent blog
+  post][error-blog].
 - Switched fasta/q parsing to use [needletail](https://github.com/onecodex/needletail)
   instead of rust-bio. See [benchmark] for improvement in runtimes.
 - Changed the way Illumina paired reads are subsampled. Previously, there was an
@@ -37,38 +52,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0]
 
-Version 0.3.0 may give different results to previous versions. If so,
-the differences will likely be a handful of extra reads (possibly none).
-The reason for this is `--coverage` is now treated as a float.
-Previously we immediately round coverage down to the nearest integer. As
-the number of reads to keep is based on the target total number of
-bases, which is coverage * genome size. So if coverage is 10.7 and
-genome size is 100, previously our target number of bases would have
-been 1000, whereas now, it would be 1070.
+Version 0.3.0 may give different results to previous versions. If so, the differences
+will likely be a handful of extra reads (possibly none). The reason for this is
+`--coverage` is now treated as a float. Previously we immediately round coverage down to
+the nearest integer. As the number of reads to keep is based on the target total number
+of bases, which is coverage * genome size. So if coverage is 10.7 and genome size is
+100, previously our target number of bases would have been 1000, whereas now, it would
+be 1070.
 
 ### Changed
-- `--coverage` is now treated as a `f32` instead of being converted
-  immediately to an integer [#19][19].
-- Updated `rust-bio` to version 0.31.0. This means `rasusa` now handles
-  wrapped fastq files.
-- Preallocate fastx records instead of using iterator. Gives marginal
-  speedup.
+
+- `--coverage` is now treated as a `f32` instead of being converted immediately to an
+  integer [#19][19].
+- Updated `rust-bio` to version 0.31.0. This means `rasusa` now handles wrapped fastq
+  files.
+- Preallocate fastx records instead of using iterator. Gives marginal speedup.
 - Added `bash` to the docker image b47a8b75943098bdd845b7758cf2eab01ef5a3d8
 
 ## [0.2.0]
 
 ### Added
+
 - Support paired Illumina [#15](https://github.com/mbhall88/rasusa/issues/15)
 
-
-[unreleased]: https://github.com/mbhall88/rasusa/compare/0.4.2...HEAD
-[0.4.2]: https://github.com/mbhall88/rasusa/releases/tag/0.4.2
-[0.4.1]: https://github.com/mbhall88/rasusa/releases/tag/0.4.1
-[0.4.0]: https://github.com/mbhall88/rasusa/releases/tag/0.4.0
-[0.3.0]: https://github.com/mbhall88/rasusa/releases/tag/0.3.0
 [0.2.0]: https://github.com/mbhall88/rasusa/releases/tag/0.2.0
+[0.3.0]: https://github.com/mbhall88/rasusa/releases/tag/0.3.0
+[0.4.0]: https://github.com/mbhall88/rasusa/releases/tag/0.4.0
+[0.4.1]: https://github.com/mbhall88/rasusa/releases/tag/0.4.1
+[0.4.2]: https://github.com/mbhall88/rasusa/releases/tag/0.4.2
 [19]: https://github.com/mbhall88/rasusa/issues/19
 [22]: https://github.com/mbhall88/rasusa/issues/22
+[27]: https://github.com/mbhall88/rasusa/issues/27
 [28]: https://github.com/mbhall88/rasusa/pull/28
 [benchmark]: https://github.com/mbhall88/rasusa#benchmark
 [error-blog]: https://nick.groenen.me/posts/rust-error-handling/
+[unreleased]: https://github.com/mbhall88/rasusa/compare/0.4.2...HEAD
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bgzip"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b24c7834de214cf8da3054a155602eb727eba3bb4bbd07f3114f337421c15acf"
+dependencies = [
+ "flate2",
+ "thiserror",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "cgmath"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,7 +207,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -227,7 +243,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -254,7 +270,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -292,7 +308,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -332,6 +348,20 @@ dependencies = [
  "bzip2",
  "flate2",
  "memchr",
+ "xz2",
+]
+
+[[package]]
+name = "niffler"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a7f12f3a029d01c9018f80bf5335b0f39f26c1cc898d394e8b72db09ee7957"
+dependencies = [
+ "bgzip",
+ "bzip2",
+ "cfg-if 1.0.0",
+ "flate2",
+ "thiserror",
  "xz2",
 ]
 
@@ -528,6 +558,7 @@ dependencies = [
  "fern",
  "log",
  "needletail",
+ "niffler",
  "predicates",
  "rand 0.7.2",
  "rand_pcg",
@@ -674,7 +705,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.2",
  "redox_syscall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license-file = "LICENSE"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-structopt = "0.3.2"
+structopt = "0.3"
 clap = "2.33.0"
 regex = "1"
 thiserror = "1.0"
@@ -27,6 +27,7 @@ rand_pcg = "0.2.1"
 log = "0.4"
 fern = { version = "0.5", features = ["colored"] }
 chrono = "0.4"
+niffler = "2.3"
 
 [dev-dependencies]
 assert_cmd = "0.10"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ number of options available.
 
 [![Crates.io](https://img.shields.io/crates/v/rasusa.svg)](https://crates.io/crates/rasusa)
 
-Prerequisite: [`rust` toolchain][rust] (min. v1.51.0)
+Prerequisite: [`rust` toolchain][rust] (min. v1.53.0)
 
 ```sh
 cargo install rasusa

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Ra**ndomly **su**b**sa**mple sequencing reads to a specified coverage.
 
-[TOC]:#
+[TOC]: #
 
 ## Table of Contents
 - [Motivation](#motivation)
@@ -32,31 +32,44 @@
 - [Citing](#citing)
   - [Bibtex](#bibtex)
 
-
 ## Motivation
 
-I couldn't find a tool for subsampling reads that met my requirements. All the strategies I could find fell short as they either just wanted a number or  percentage of reads to subsample to or, if they did subsample to a coverage, they assume all reads are the same size (i.e Illumina). As I mostly work with long-read data this posed a problem if I wanted to subsample a file to certain coverage, as length of reads was never taken into account. `rasusa` addresses this shortcoming.
+I couldn't find a tool for subsampling reads that met my requirements. All the
+strategies I could find fell short as they either just wanted a number or percentage of
+reads to subsample to or, if they did subsample to a coverage, they assume all reads are
+the same size (i.e Illumina). As I mostly work with long-read data this posed a problem
+if I wanted to subsample a file to certain coverage, as length of reads was never taken
+into account. `rasusa` addresses this shortcoming.
 
-A workaround I had been using for a while was using [`filtlong`][filtlong]. It was simple enough, I just figure out the number of bases I need to achieve a (theoretical) coverage for my sample. Say I have a fastq from an _E. coli_ sample with 5 million reads and I want to subset it to 50x coverage. I just need to multiply the expected size of the sample's genome, 4.6 million base pairs, by the coverage I want and I have my target bases - 230 million base pairs. In `filtlong`, I can do the following
+A workaround I had been using for a while was using [`filtlong`][filtlong]. It was
+simple enough, I just figure out the number of bases I need to achieve a (theoretical)
+coverage for my sample. Say I have a fastq from an _E. coli_ sample with 5 million reads
+and I want to subset it to 50x coverage. I just need to multiply the expected size of
+the sample's genome, 4.6 million base pairs, by the coverage I want and I have my target
+bases - 230 million base pairs. In `filtlong`, I can do the following
 
 ```sh
 target=230000000
 filtlong --target_bases "$target" reads.fq > reads.50x.fq
 ```
 
-However, this is technically not the intended function of `filtlong`; it's a quality filtering tool. What you get in the end is a subset of the ["highest scoring"][score] reads at a (theoretical) coverage of 50x. Depending on your circumstances, this might be what you want. However, you bias yourself towards the best/longest reads in the dataset - not a fair representation of your dataset as a whole. There is also the possibility of favouring regions of the genome that produce longer/higher quality reads. [De Maio _et al._][mgen-ref] even found that by randomly subsampling nanopore reads you achieve _better_ genome assemblies than if you had filtered.  
+However, this is technically not the intended function of `filtlong`; it's a quality
+filtering tool. What you get in the end is a subset of the ["highest scoring"][score]
+reads at a (theoretical) coverage of 50x. Depending on your circumstances, this might be
+what you want. However, you bias yourself towards the best/longest reads in the dataset
+\- not a fair representation of your dataset as a whole. There is also the possibility
+of favouring regions of the genome that produce longer/higher quality reads. [De Maio
+_et al._][mgen-ref] even found that by randomly subsampling nanopore reads you achieve
+_better_ genome assemblies than if you had filtered.
 
-So, depending on your circumstances, an unbiased subsample of your reads might be what you need. And if this is the case, `rasusa` has you covered.
-
-[mgen-ref]: https://doi.org/10.1099/mgen.0.000294
-
-[filtlong]: https://github.com/rrwick/Filtlong
-
-[score]: https://github.com/rrwick/Filtlong#read-scoring
+So, depending on your circumstances, an unbiased subsample of your reads might be what
+you need. And if this is the case, `rasusa` has you covered.
 
 ## Install
 
-Some of these installation options require the [`rust` toolchain][rust], which is extremely easy to set up. However, if you do not wish to install `rust` then there are a number of options available.
+Some of these installation options require the [`rust` toolchain][rust], which is
+extremely easy to set up. However, if you do not wish to install `rust` then there are a
+number of options available.
 
 ### `cargo`
 
@@ -79,11 +92,8 @@ Prerequisite: [`conda`][conda] (and bioconda channel [correctly set up][channels
 conda install rasusa
 ```
 
-Thank you to Devon Ryan ([@dpryan79][dpryan79]) for [help debugging the bioconda recipe][pr-help].
-
-[channels]: https://bioconda.github.io/user/install.html#set-up-channels
-[dpryan79]: https://github.com/dpryan79
-[pr-help]: https://github.com/bioconda/bioconda-recipes/pull/18690
+Thank you to Devon Ryan ([@dpryan79][dpryan79]) for [help debugging the bioconda
+recipe][pr-help].
 
 ### Container
 
@@ -108,6 +118,7 @@ URI="docker://quay.io/mbhall88/rasusa:${VERSION}"
 ```
 
 #### `docker`
+
 [![Docker Repository on Quay](https://quay.io/repository/mbhall88/rasusa/status "Docker Repository on Quay")](https://quay.io/repository/mbhall88/rasusa)
 
 Prerequisite: [`docker`][docker]
@@ -117,13 +128,8 @@ docker pull quay.io/mbhall88/rasusa
 docker run quay.io/mbhall88/rasusa rasusa --help
 ```
 
-[dockerhub]: https://hub.docker.com/r/mbhall88/rasusa
-[quay.io]: https://quay.io/repository/mbhall88/rasusa
-
-
-You can find all the available tags on the [quay.io repository][quay.io]. Note: versions prior
-to 0.4.0 were housed on [Docker Hub](https://hub.docker.com/r/mbhall88/rasusa).
-
+You can find all the available tags on the [quay.io repository][quay.io]. Note: versions
+prior to 0.4.0 were housed on [Docker Hub](https://hub.docker.com/r/mbhall88/rasusa).
 
 ### `homebrew`
 
@@ -142,11 +148,11 @@ or
 brew install brewsci/bio/rasusa
 ```
 
-[brew-tap]: https://github.com/brewsci/homebrew-bio
-
 ### Release binaries
 
-**tl;dr**: Run the following snippet to download the binary for your system to the current directory and show the help menu.
+**tl;dr**: Run the following snippet to download the binary for your system to the
+current directory and show the help menu.
+
 ```shell
 OS=$(uname -s)                                                                                                       
 if [ "$OS" = "Linux" ]; then                                                                                         
@@ -170,16 +176,15 @@ Currently, there are two pre-compiled binaries available:
 - OSX kernel `x86_64-apple-darwin` (works for any post-2007 Mac)
 
 An example of downloading one of these binaries using `wget`
+
 ```sh
 URL="https://github.com/mbhall88/rasusa/releases/download/0.4.2/rasusa-0.4.2-x86_64-unknown-linux-musl.tar.gz"
 wget "$URL" -O - | tar -xzf -
 ./rasusa --help
 ```
 
-If these binaries do not work on your system please raise an issue and I will potentially
-add some additional [target triples][triples].
-
-[triples]: https://clang.llvm.org/docs/CrossCompilation.html#target-triple
+If these binaries do not work on your system please raise an issue and I will
+potentially add some additional [target triples][triples].
 
 ### Build locally
 
@@ -193,16 +198,6 @@ target/release/rasusa --help
 # if you want to check everything is working ok
 cargo test --all
 ```
-
-[rust]: https://www.rust-lang.org/tools/install
-
-[conda]: https://docs.conda.io/projects/conda/en/latest/user-guide/install/
-
-[singularity]: https://sylabs.io/guides/3.4/user-guide/quick_start.html#quick-installation-steps
-
-[docker]: https://docs.docker.com/v17.12/install/
-
-[homebrew]: https://docs.brew.sh/Installation
 
 ## Usage
 
@@ -230,18 +225,20 @@ There are three required options to run `rasusa`.
 
 ##### `-i`, `--input`
 
-This option specifies the file(s) containing the reads you would like to subsample.
-The file(s) must be valid fasta or fastq format and can be compressed (with a tool such as `gzip`).  
+This option specifies the file(s) containing the reads you would like to subsample. The
+file(s) must be valid fasta or fastq format and can be compressed (with a tool such as
+`gzip`).  
 Illumina paired files can be passed in two ways.
 1. Using `--input` twice `-i r1.fq -i r2.fq`
 2. Using `--input` once, but passing both files immediately after `-i r1.fq r2.fq`
 
 > Bash wizard tip 🧙: Let globs do the work for you `-i r*.fq`
 
-_**Note**: The file format is (lazily) determined from the file name._ File suffixes that are deemed valid are:
+_**Note**: The file format is (lazily) determined from the file name._ File suffixes
+that are deemed valid are:
 
--   fasta: `.fa`, `.fasta`, `.fa.gz`, `.fasta.gz`
--   fastq: `.fq`, `.fastq`, `.fq.gz`, `.fastq.gz`
+- fasta: `.fa`, `.fasta`, `.fa.gz`, `.fasta.gz`
+- fastq: `.fq`, `.fastq`, `.fq.gz`, `.fastq.gz`
 
 If there is a naming convention you feel is missing, please raise an issue.
 
@@ -249,29 +246,32 @@ If there is a naming convention you feel is missing, please raise an issue.
 
 ##### `-c`, `--coverage`
 
-This option is used to determine the minimum coverage to subsample the
-reads to. It can be specified as an integer (100), a decimal/float
-(100.7), or either of the previous suffixed with an 'x' (100x).
+This option is used to determine the minimum coverage to subsample the reads to. It can
+be specified as an integer (100), a decimal/float (100.7), or either of the previous
+suffixed with an 'x' (100x).
 
-
-_**Note**: Due to the method for determining how many bases are required
-to achieve the desired coverage, the actual coverage, in the end, could
-be slightly higher than requested. For example, if the last included
-read is very long. The log messages should inform you of the actual
-coverage in the end._
+_**Note**: Due to the method for determining how many bases are required to achieve the
+desired coverage, the actual coverage, in the end, could be slightly higher than
+requested. For example, if the last included read is very long. The log messages should
+inform you of the actual coverage in the end._
 
 #### Genome size
 
 ##### `-g`, `--genome-size`
 
-The genome size of the input is also required. It is used to determine how many bases are necessary to achieve the desired coverage. This can, of course, be as precise or rough as you like.  
-Genome size can be passed in many ways. As a plain old integer (1600), or with a metric suffix (1.6kb). All metric suffixes can have an optional 'b' suffix and be lower, upper, or mixed case. So 'Kb', 'kb' and 'k' would all be inferred as 'kilo'. Valid metric suffixes include:
+The genome size of the input is also required. It is used to determine how many bases
+are necessary to achieve the desired coverage. This can, of course, be as precise or
+rough as you like.  
+Genome size can be passed in many ways. As a plain old integer (1600), or with a metric
+suffix (1.6kb). All metric suffixes can have an optional 'b' suffix and be lower, upper,
+or mixed case. So 'Kb', 'kb' and 'k' would all be inferred as 'kilo'. Valid metric
+suffixes include:
 
--   Base (b) - multiplies by 1
--   Kilo (k) - multiplies by 1,000
--   Mega (m) - multiplies by 1,000,000
--   Giga (g) - multiplies by 1,000,000,000
--   Tera (t) - multiplies by 1,000,000,000,000
+- Base (b) - multiplies by 1
+- Kilo (k) - multiplies by 1,000
+- Mega (m) - multiplies by 1,000,000
+- Giga (g) - multiplies by 1,000,000,000
+- Tera (t) - multiplies by 1,000,000,000,000
 
 ### Optional parameters
 
@@ -281,30 +281,70 @@ Genome size can be passed in many ways. As a plain old integer (1600), or with a
 
 NOTE: This parameter is required if passing paired Illumina data.
 
-By default, `rasusa` will output the subsampled file to `stdout` (if one file is given). If you would prefer to specify an output file path, then use this option. If you add the compression suffix `.gz` to the file path then the output will be compressed for you.
+By default, `rasusa` will output the subsampled file to `stdout` (if one file is given).
+If you would prefer to specify an output file path, then use this option.
 
-Output for Illumina paired files can be specified in the same manner as [`--input`](#input)
+Output for Illumina paired files can be specified in the same manner as
+[`--input`](#input)
 1. Using `--output` twice `-o out.r1.fq -o out.r2.fq`
-2. Using `--output` once, but passing both files immediately after `-o out.r1.fq out.r2.fq`
+2. Using `--output` once, but passing both files immediately after `-o out.r1.fq
+   out.r2.fq`
 
 The ordering of the output files is assumed to be the same as the input.  
-_Note: The output will always be in the same format as the input. You cannot pass fastq as input and ask for fasta as output._
+_Note: The output will always be in the same format as the input. You cannot pass fastq
+as input and ask for fasta as output._
+
+`rasusa` will also attempt to automatically infer whether comression of the output
+file(s) is required. It does this by detecting any of the supported extensions:
+- `.gz`: will compress the output with [`gzip`][gzip]
+- `.bz` or `.bz2`: will compress the output with [`bzip2`][bzip]
+- `.lzma`: will compress the output with the [`xz`][xz] LZMA algorithm
+
+[gzip]: http://www.gzip.org/
+[bzip]: https://sourceware.org/bzip2/
+[xz]: https://tukaani.org/xz/
+
+#### Output compression format
+
+##### `-O`, `--output-type`
+
+Use this option to manually set the compression algoritm to use for the output file(s).
+It will override any format automatically detected from the output path.
+
+Valid options are:
+- `g`: [`gzip`][gzip]
+- `b`: [`bzip2`][bzip]
+- `l`: [`xz`][xz] LZMA algorithm
+- `u`: no compression
+
+*Note: these options are case insensitive.*
+
+#### Compresion level
+
+##### `-l`, `--compress-level`
+
+Compression level to use if compressing the output. 1 is for fastest/least compression
+and 9 is for slowest/best. By default this is set to 6, which is also the default for
+most compression programs.
 
 #### Random seed
 
 ##### `-s`, `--seed`
 
-This option allows you to specify the [random seed][seed] used by the random subsampler. By explicitly setting this parameter, you make the subsample for the input reproducible. The seed is an integer, and by default it is not set, meaning the operating system will seed the random subsampler. You should only pass this parameter if you are likely to want to subsample the same input file again in the future and want the same subset of reads.
-
-[seed]: https://en.wikipedia.org/wiki/Random_seed
+This option allows you to specify the [random seed][seed] used by the random subsampler.
+By explicitly setting this parameter, you make the subsample for the input reproducible.
+The seed is an integer, and by default it is not set, meaning the operating system will
+seed the random subsampler. You should only pass this parameter if you are likely to
+want to subsample the same input file again in the future and want the same subset of
+reads.
 
 #### Verbosity
 
 ##### `-v`
 
-Adding this optional flag will make the logging more verbose. By default, logging will produce messages considered "info" or above (see [here][log-lvl] for more details). If verbosity is switched on, you will additionally get "debug" level logging messages.
-
-[log-lvl]: https://docs.rs/log/0.4.6/log/enum.Level.html#variants
+Adding this optional flag will make the logging more verbose. By default, logging will
+produce messages considered "info" or above (see [here][log-lvl] for more details). If
+verbosity is switched on, you will additionally get "debug" level logging messages.
 
 ### Full usage
 
@@ -315,29 +355,53 @@ rasusa 0.4.2
 Randomly subsample reads to a specified coverage.
 
 USAGE:
-    rasusa [FLAGS] [OPTIONS] --coverage <coverage> --genome-size <genome-size> --input <input>...
+    rasusa [FLAGS] [OPTIONS] --coverage <FLOAT> --genome-size <genome-size> --input <input>...
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v               Switch on verbosity.
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
+    -v
+            Switch on verbosity.
+
 
 OPTIONS:
-    -c, --coverage <coverage>          The desired coverage to sub-sample the reads to.
-    -g, --genome-size <genome-size>    Size of the genome to calculate coverage with respect to. i.e 4.3kb, 7Tb, 9000,
-                                       4.1MB etc.
-    -i, --input <input>...             The fast{a,q} file(s) to subsample. For paired Illumina you may either pass this
-                                       flag twice `-i r1.fq -i r2.fq` or give two files consecutively `-i r1.fq r2.fq`.
-    -o, --output <output>...           Output file(s), stdout if not present. For paired Illumina you may either pass
-                                       this flag twice `-o o1.fq -o o2.fq` or give two files consecutively `-o o1.fq
-                                       o2.fq`. NOTE: The order of the pairs is assumed to be the same as that given for
-                                       --input. This option is required for paired input.
-    -s, --seed <seed>                  Random seed to use.
+    -l, --compress-level <1-9>
+            Compression level to use if compressing output [default: 6]
+
+    -c, --coverage <FLOAT>
+            The desired coverage to sub-sample the reads to.
+
+    -g, --genome-size <genome-size>
+            Genome size to calculate coverage with respect to. e.g., 4.3kb, 7Tb, 9000, 4.1MB
+
+    -i, --input <input>...
+            The fast{a,q} file(s) to subsample.
+
+            For paired Illumina you may either pass this flag twice `-i r1.fq -i r2.fq` or give two files consecutively
+            `-i r1.fq r2.fq`.
+    -o, --output <output>...
+            Output filepath(s); stdout if not present.
+
+            For paired Illumina you may either pass this flag twice `-o o1.fq -o o2.fq` or give two files consecutively
+            `-o o1.fq o2.fq`. NOTE: The order of the pairs is assumed to be the same as that given for --input. This
+            option is required for paired input.
+    -O, --output-type <u|b|g|l>
+            u: uncompressed; b: Bzip2; g: Gzip; l: Lzma
+
+            Rasusa will attempt to infer the output compression format automatically from the filename extension. This
+            option is used to override that. If writing to stdout, the default is uncompressed
+    -s, --seed <INT>
+            Random seed to use.
 ```
 
 ### Snakemake
 
-If you want to use `rasusa` in a [`snakemake`][snakemake] pipeline, it is advised to use the [wrapper][wrapper].
+If you want to use `rasusa` in a [`snakemake`][snakemake] pipeline, it is advised to use
+the [wrapper][wrapper].
 
 ```py
 rule subsample:
@@ -357,32 +421,38 @@ rule subsample:
         "0.70.0/bio/rasusa"
 ```
 
-*See the [latest wrapper][wrapper] documentation for the most up-to-date version number.*
-
-[snakemake]: https://snakemake.readthedocs.io/en/stable/
-[wrapper]: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/rasusa.html
+*See the [latest wrapper][wrapper] documentation for the most up-to-date version
+number.*
 
 ## Benchmark
 
 > “Time flies like an arrow; fruit flies like a banana.”  
-― Anthony G. Oettinger
+> ― Anthony G. Oettinger
 
-The real question is: will `rasusa` just needlessly eat away at your precious time on earth?
+The real question is: will `rasusa` just needlessly eat away at your precious time on
+earth?
 
 To do this benchmark, I am going to use [hyperfine][hyperfine].
 
 The data I used comes from
 
-> [Bainomugisa, Arnold, et al. "A complete high-quality MinION nanopore assembly of an extensively drug-resistant Mycobacterium tuberculosis Beijing lineage strain identifies novel variation in repetitive PE/PPE gene regions." Microbial genomics 4.7 (2018).][1]
+> [Bainomugisa, Arnold, et al. "A complete high-quality MinION nanopore assembly of an
+> extensively drug-resistant Mycobacterium tuberculosis Beijing lineage strain
+> identifies novel variation in repetitive PE/PPE gene regions." Microbial genomics 4.7
+> (2018).][1]
 
 ### Single long read input
+
 Download and rename the fastq
+
 ```shell
 URL="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR649/008/SRR6490088/SRR6490088_1.fastq.gz"
 wget "$URL" -O - | gzip -d -c > tb.fq
 ```
+
 The file size is 2.9G, and it has 379,547 reads.  
-We benchmark against `filtlong` using the same strategy outlined in [Motivation](#motivation).
+We benchmark against `filtlong` using the same strategy outlined in
+[Motivation](#motivation).
 
 ```shell
 TB_GENOME_SIZE=4411532
@@ -395,25 +465,28 @@ hyperfine --warmup 3 --runs 10 --export-markdown results-single.md \
 ```
 
 #### Results
-| Command | Mean [s] | Min [s] | Max [s] | Relative |
-|:---|---:|---:|---:|---:|
-| `filtlong --target_bases 220576600 tb.fq` | 21.685 ± 0.055 | 21.622 | 21.787 | 21.77 ± 0.29 |
-| `rasusa -i tb.fq -c 50 -g 4411532 -s 1` | 0.996 ±  0.013 | 0.983 | 1.023 | 1.00 |
+
+| Command                                   |       Mean [s] | Min [s] | Max [s] |     Relative |
+|:------------------------------------------|---------------:|--------:|--------:|-------------:|
+| `filtlong --target_bases 220576600 tb.fq` | 21.685 ± 0.055 |  21.622 |  21.787 | 21.77 ± 0.29 |
+| `rasusa -i tb.fq -c 50 -g 4411532 -s 1`   | 0.996 ±  0.013 |   0.983 |   1.023 |         1.00 |
 
 **Summary**: `rasusa` ran 21.77 ± 0.29 times faster than `filtlong`.
-
 
 ### Paired-end input
 
 Download and then deinterleave the fastq with [`pyfastaq`][pyfastaq]
+
 ```shell
 URL="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR648/008/SRR6488968/SRR6488968.fastq.gz"
 wget "$URL" -O - | gzip -d -c - | fastaq deinterleave - r1.fq r2.fq
 ```
+
 Each file's size is 179M and has 283,590 reads.  
 For this benchmark, we will use [`seqtk`][seqtk]. As `seqtk` requires a fixed number of
 reads to subsample to, I ran `rasusa` initially and got the number of reads it was using
-for its subsample. We will also test `seqtk`'s 2-pass mode as this is analogous to `rasusa`.  
+for its subsample. We will also test `seqtk`'s 2-pass mode as this is analogous to
+`rasusa`.  
 We use a lower coverage for the Illumina as the samples only have ~38x coverage.
 
 ```shell
@@ -442,30 +515,28 @@ So, `rasusa` is faster than `seqtk` but doesn't require a fixed number of reads 
 allowing you to avoid doing maths to determine how many reads you need to downsample to
 a specific coverage. 🤓
 
-[hyperfine]: https://github.com/sharkdp/hyperfine
-[1]: https://doi.org/10.1099/mgen.0.000188
-[pyfastaq]: https://github.com/sanger-pathogens/Fastaq
-[seqtk]: https://github.com/lh3/seqtk
-
 ## Contributing
 
-If you would like to help improve `rasusa` you are very welcome!  
+If you would like to help improve `rasusa` you are very welcome!
 
 For changes to be accepted, they must pass the CI and coverage checks. These include:
 
--   Code is formatted with `rustfmt`. This can be done by running `cargo fmt` in the project directory.
--   There are no compiler errors/warnings. You can check this by running `cargo clippy --all-features --all-targets -- -D warnings`
--   Code coverage has not reduced. If you want to check coverage before pushing changes, I use [`kcov`][kcov].
-
-[kcov]: https://github.com/SimonKagstrom/kcov
+- Code is formatted with `rustfmt`. This can be done by running `cargo fmt` in the
+  project directory.
+- There are no compiler errors/warnings. You can check this by running `cargo clippy
+  --all-features --all-targets -- -D warnings`
+- Code coverage has not reduced. If you want to check coverage before pushing changes, I
+  use [`kcov`][kcov].
 
 ## Citing
 
-If you use `rasusa` in your research, it would be very much appreciated if you could cite it.
+If you use `rasusa` in your research, it would be very much appreciated if you could
+cite it.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3731394.svg)](https://doi.org/10.5281/zenodo.3731394)
 
-> Hall, Michael B. Rasusa: Randomly subsample sequencing reads to a specified coverage. (2019). doi:10.5281/zenodo.3731394
+> Hall, Michael B. Rasusa: Randomly subsample sequencing reads to a specified coverage.
+> (2019). doi:10.5281/zenodo.3731394
 
 ### Bibtex
 
@@ -480,3 +551,29 @@ If you use `rasusa` in your research, it would be very much appreciated if you c
     month={Nov}
 }
 ```
+
+[1]: https://doi.org/10.1099/mgen.0.000188
+[brew-tap]: https://github.com/brewsci/homebrew-bio
+[channels]: https://bioconda.github.io/user/install.html#set-up-channels
+[conda]: https://docs.conda.io/projects/conda/en/latest/user-guide/install/
+[docker]: https://docs.docker.com/v17.12/install/
+[dockerhub]: https://hub.docker.com/r/mbhall88/rasusa
+[dpryan79]: https://github.com/dpryan79
+[filtlong]: https://github.com/rrwick/Filtlong
+[homebrew]: https://docs.brew.sh/Installation
+[hyperfine]: https://github.com/sharkdp/hyperfine
+[kcov]: https://github.com/SimonKagstrom/kcov
+[log-lvl]: https://docs.rs/log/0.4.6/log/enum.Level.html#variants
+[mgen-ref]: https://doi.org/10.1099/mgen.0.000294
+[pr-help]: https://github.com/bioconda/bioconda-recipes/pull/18690
+[pyfastaq]: https://github.com/sanger-pathogens/Fastaq
+[quay.io]: https://quay.io/repository/mbhall88/rasusa
+[rust]: https://www.rust-lang.org/tools/install
+[score]: https://github.com/rrwick/Filtlong#read-scoring
+[seed]: https://en.wikipedia.org/wiki/Random_seed
+[seqtk]: https://github.com/lh3/seqtk
+[singularity]: https://sylabs.io/guides/3.4/user-guide/quick_start.html#quick-installation-steps
+[snakemake]: https://snakemake.readthedocs.io/en/stable/
+[triples]: https://clang.llvm.org/docs/CrossCompilation.html#target-triple
+[wrapper]: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/rasusa.html
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 **Ra**ndomly **su**b**sa**mple sequencing reads to a specified coverage.
 
 [TOC]: #
-
 ## Table of Contents
 - [Motivation](#motivation)
 - [Install](#install)
@@ -75,7 +74,7 @@ number of options available.
 
 [![Crates.io](https://img.shields.io/crates/v/rasusa.svg)](https://crates.io/crates/rasusa)
 
-Prerequisite: [`rust` toolchain][rust] (min. v1.43.0)
+Prerequisite: [`rust` toolchain][rust] (min. v1.51.0)
 
 ```sh
 cargo install rasusa

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,10 @@ fn main() -> Result<()> {
     let input_fastx = Fastx::from_path(&args.input[0]);
 
     let mut output_handle = match args.output.len() {
-        0 => Box::new(stdout()),
+        0 => match args.output_type {
+            None => Box::new(stdout()),
+            Some(fmt) => niffler::basic::get_writer(Box::new(stdout()), fmt, compress_level)?,
+        },
         _ => {
             let out_fastx = Fastx::from_path(&args.output[0]);
             out_fastx


### PR DESCRIPTION
### Added

- Support for LZMA, Bzip, and Gzip output compression (thanks to
  [`niffler`](https://github.com/luizirber/niffler/)). This is either inferred from the file extension or manually via the `-O` option.
- Option to specify the compression level for the output via `-l`

### Fixed
- Restore compression of output files [closes #27]