### PR TITLE
Add option to explicitly set the target number of bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Addedd
+- `--bases` option to allow for manually setting the target number of bases to keep
+  [[#30][30]]
+
+
 ## [0.5.0]
 
 ### Added
@@ -86,6 +91,7 @@ be 1070.
 [19]: https://github.com/mbhall88/rasusa/issues/19
 [22]: https://github.com/mbhall88/rasusa/issues/22
 [27]: https://github.com/mbhall88/rasusa/issues/27
+[30]: https://github.com/mbhall88/rasusa/issues/30
 [28]: https://github.com/mbhall88/rasusa/pull/28
 [benchmark]: https://github.com/mbhall88/rasusa#benchmark
 [error-blog]: https://nick.groenen.me/posts/rust-error-handling/

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Illumina paired files can be passed in two ways.
 
 ##### `-c`, `--coverage`
 
+> Not required if [`--bases`](#target-number-of-bases) is present
+
 This option is used to determine the minimum coverage to subsample the reads to. It can
 be specified as an integer (100), a decimal/float (100.7), or either of the previous
 suffixed with an 'x' (100x).
@@ -249,6 +251,8 @@ inform you of the actual coverage in the end._
 #### Genome size
 
 ##### `-g`, `--genome-size`
+
+> Not required if [`--bases`](#target-number-of-bases) is present
 
 The genome size of the input is also required. It is used to determine how many bases
 are necessary to achieve the desired coverage. This can, of course, be as precise or
@@ -318,6 +322,16 @@ Compression level to use if compressing the output. 1 is for fastest/least compr
 and 9 is for slowest/best. By default this is set to 6, which is also the default for
 most compression programs.
 
+#### Target number of bases
+
+##### `-b`, `--bases`
+
+Explicitly set the number of bases required in the subsample. This option takes the
+number in the same format as [genome size](#genome-size).
+
+*Note: if this option is given, genome size and coverage are not required, or ignored if
+they are provided.*
+
 #### Random seed
 
 ##### `-s`, `--seed`
@@ -346,7 +360,7 @@ rasusa 0.5.0
 Randomly subsample reads to a specified coverage.
 
 USAGE:
-    rasusa [FLAGS] [OPTIONS] --coverage <FLOAT> --genome-size <genome-size> --input <input>...
+    rasusa [FLAGS] [OPTIONS] --bases <bases> --coverage <FLOAT> --genome-size <genome-size> --input <input>...
 
 FLAGS:
     -h, --help
@@ -360,15 +374,21 @@ FLAGS:
 
 
 OPTIONS:
+    -b, --bases <bases>
+            Explicitly set the number of bases required e.g., 4.3kb, 7Tb, 9000, 4.1MB
+
+            If this option is given, --coverage and --genome-size are ignored
     -l, --compress-level <1-9>
             Compression level to use if compressing output [default: 6]
 
     -c, --coverage <FLOAT>
-            The desired coverage to sub-sample the reads to.
+            The desired coverage to sub-sample the reads to
 
+            If --bases is not provided, this option and --genome-size are required
     -g, --genome-size <genome-size>
             Genome size to calculate coverage with respect to. e.g., 4.3kb, 7Tb, 9000, 4.1MB
 
+            If --bases is not provided, this option and --coverage are required
     -i, --input <input>...
             The fast{a,q} file(s) to subsample.
 
@@ -386,7 +406,7 @@ OPTIONS:
             Rasusa will attempt to infer the output compression format automatically from the filename extension. This
             option is used to override that. If writing to stdout, the default is uncompressed
     -s, --seed <INT>
-            Random seed to use.
+            Random seed to use..
 ```
 
 ### Snakemake

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,11 @@ fn main() -> Result<()> {
         }
     };
 
-    let target_total_bases: u64 = args.genome_size * args.coverage;
+    let target_total_bases: u64 = match (args.genome_size, args.coverage, args.bases) {
+        (_, _, Some(bases)) => u64::from(bases),
+        (Some(gsize), Some(cov), _) => gsize * cov,
+        _ => panic!("Require either target bases or both coverage and genome size - should not have gotten to this point before failing. Please report!")
+    };
     info!(
         "Target number of bases to subsample to is: {}",
         target_total_bases
@@ -141,8 +145,12 @@ fn main() -> Result<()> {
         )? as u64;
     }
 
-    let actual_covg = total_kept_bases / args.genome_size;
-    info!("Actual coverage of kept reads is {:.2}x", actual_covg);
+    if let Some(gsize) = args.genome_size {
+        let actual_covg = total_kept_bases / gsize;
+        info!("Actual coverage of kept reads is {:.2}x", actual_covg);
+    } else {
+        info!("Kept {} bases", total_kept_bases);
+    }
 
     info!("Done 🎉");
 


### PR DESCRIPTION
Added the following option

```
    -b, --bases <bases>
            Explicitly set the number of bases required e.g., 4.3kb, 7Tb, 9000, 4.1MB

            If this option is given, --coverage and --genome-size are ignored
```

Closes #30 