### PR TITLE
ci(bench): S1 · Benchmark harness (runtime + peak memory) + baseline

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,99 @@
+name: Benchmark
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+  schedule:
+    # First of the month, 03:00 UTC - keeps the published numbers from going stale
+    # between releases.
+    - cron: "0 3 1 * *"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update-readme-benchmark:
+    name: Regenerate README benchmark tables
+    # Pinned (not `ubuntu-latest`) since the whole point of this job is producing
+    # numbers on a stable, known runner - a silent image bump shouldn't move them.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          # Needed so the commit-back step has a real branch to push to.
+          fetch-depth: 1
+
+      # Loop-guard: this workflow commits back to `main` with a tagged message. It isn't
+      # push-triggered, so it can't retrigger itself directly, but `workflow_dispatch`/
+      # `schedule` firing right after such a commit would otherwise just redo the same
+      # work - skip in that case.
+      - name: Check loop-guard
+        id: guard
+        run: |
+          if git log -1 --pretty=%B | grep -qF '[skip benchmark]'; then
+            echo "HEAD is a bench-refresh commit, skipping this run." >&2
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install toolchain
+        if: steps.guard.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v5
+        if: steps.guard.outputs.skip != 'true'
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cache downloaded benchmark datasets
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/cache@v5
+        with:
+          path: data/download-cache
+          key: bench-datasets-v1
+
+      - name: Install hyperfine
+        if: steps.guard.outputs.skip != 'true'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: hyperfine
+
+      - name: Install filtlong, seqtk, fastaq (bioconda)
+        if: steps.guard.outputs.skip != 'true'
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: bench-tools
+          create-args: -c bioconda -c conda-forge filtlong seqtk fastaq
+          init-shell: bash
+
+      - name: Regenerate README benchmark tables
+        if: steps.guard.outputs.skip != 'true'
+        shell: bash -leo pipefail {0}
+        run: benches/update_readme.sh
+
+      - name: Commit refreshed README
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "No benchmark changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore(bench): refresh README benchmark tables [skip benchmark]"
+          git push "https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}.git" HEAD:main
+        env:
+          GH_PAT: ${{ secrets.PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/*.rs.bk
 .idea/
 code_coverage_report.sh
-data
+/data
 benchmark
 .DS_Store
+benches/results/

--- a/README.md
+++ b/README.md
@@ -679,6 +679,13 @@ The data I used comes from
 > [!NOTE]
 > These benchmarks are for `reads` only as there is no other tool that replicates the functionality of `aln`.
 
+> [!NOTE]
+> The tables below are regenerated automatically on each release by
+> [`benches/update_readme.sh`](benches/update_readme.sh), run on a GitHub Actions
+> `ubuntu-latest` runner. Absolute numbers are therefore specific to that runner and will
+> vary run to run - the meaningful figure is the **relative** speedup, not the raw
+> timings.
+
 ### Single long read input
 
 Download and rename the FASTQ
@@ -704,12 +711,14 @@ hyperfine --warmup 3 --runs 10 --export-markdown results-single.md \
 
 #### Results
 
+<!-- BENCH:single:START -->
 | Command                                      |       Mean [s] | Min [s] | Max [s] |     Relative |
 |:---------------------------------------------|---------------:|--------:|--------:|-------------:|
 | `filtlong --target_bases 220576600 tb.fq`    | 21.685 ± 0.055 |  21.622 |  21.787 | 21.77 ± 0.29 |
 | `rasusa reads tb.fq -c 50 -g 4411532 -s 1` | 0.996 ±  0.013 |   0.983 |   1.023 |         1.00 |
 
 **Summary**: `rasusa` ran 21.77 ± 0.29 times faster than `filtlong`.
+<!-- BENCH:single:END -->
 
 ### Paired-end input
 
@@ -735,6 +744,7 @@ hyperfine --warmup 10 --runs 100 --export-markdown results-paired.md \
 
 #### Results
 
+<!-- BENCH:paired:START -->
 | Command                                                                                           |     Mean [ms] | Min [ms] | Max [ms] |    Relative |
 |:--------------------------------------------------------------------------------------------------|--------------:|---------:|---------:|------------:|
 | `seqtk sample -s 1 r1.fq 140000 > /tmp/r1.fq; seqtk sample -s 1 r2.fq 140000 > /tmp/r2.fq;`       |  907.7 ± 23.6 |    875.4 |    997.8 | 1.84 ± 0.62 |
@@ -743,6 +753,7 @@ hyperfine --warmup 10 --runs 100 --export-markdown results-paired.md \
 
 **Summary**: `rasusa reads` ran 1.84 times faster than `seqtk` (1-pass) and 1.77 times faster
 than `seqtk` (2-pass)
+<!-- BENCH:paired:END -->
 
 So, `rasusa reads` is faster than `seqtk` but doesn't require a fixed number of reads -
 allowing you to avoid doing maths to determine how many reads you need to downsample to

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,126 @@
+# Benchmarks
+
+Two independent things live here:
+
+1. **`bench.sh`** - an internal A/B regression harness. Compares two git refs (or the
+   current working tree) on wall time and peak RSS, for a fixed set of scenarios. Run it
+   locally to prove a change didn't regress performance before opening a PR. (No CI job
+   runs this automatically yet - `compare origin/main` is intended to be wired into a
+   non-blocking PR check in future, but that workflow doesn't exist yet.)
+2. **`update_readme.sh`** - regenerates the tool-comparison tables in the top-level
+   `README.md` (`rasusa` vs `filtlong`/`seqtk`). This downloads real public datasets and
+   is run from a release-triggered GitHub Actions workflow
+   (`.github/workflows/benchmark.yaml`), not typically by hand.
+
+## `bench.sh`
+
+### Prerequisites
+
+- [`hyperfine`](https://github.com/sharkdp/hyperfine) for wall-time measurement.
+  Install via `brew install hyperfine` or `cargo install hyperfine`. If absent, the
+  script falls back to a portable Python timing loop with the same warmup/runs
+  semantics - slightly less precise, but no hard dependency.
+- Peak RSS is measured with whatever is available:
+  - macOS: BSD `/usr/bin/time -l` (built in).
+  - Linux: GNU `time -v` (usually `/usr/bin/time`, package `time`), or
+    [`gtime`](https://formulae.brew.sh/formula/gtime) (`brew install gnu-time`) if
+    running the Linux-style tool via Homebrew on macOS.
+  - If none are found, RSS is omitted (wall time is still measured) and a warning is
+    printed.
+- `python3` for JSON handling (`benches/lib.py`) - no third-party packages required.
+- `cargo`/`rustc`, obviously.
+
+### Usage
+
+```shell
+# Benchmark the current working tree (uncommitted changes included):
+benches/bench.sh run
+
+# Benchmark a specific git ref (branch, tag, or commit):
+benches/bench.sh run origin/main
+
+# Compare two refs head-to-head and fail if either regressed:
+benches/bench.sh compare origin/main          # base=origin/main, head=current working tree
+benches/bench.sh compare origin/main HEAD~1   # base=origin/main, head=HEAD~1
+```
+
+`run [ref]` builds `ref` in `--release` mode (a git ref is built in an isolated
+`git worktree` under `target/bench-worktrees/`; omitting `ref`, or passing `local`,
+builds the current working tree in place), runs every scenario, and writes
+`benches/results/<ref>.json` (`ref` is slash-sanitised for the filename). It prints the
+path to the written JSON file on stdout.
+
+`compare <base> [head]` runs `run` for both refs and prints a table of wall-time and
+peak-RSS ratios (`head / base`). It exits non-zero if any scenario's ratio exceeds the
+configured threshold - i.e. a regression.
+
+`benches/results/` is gitignored - it's scratch output, not a reference. The one
+committed exception is **`benches/baseline.json`**, a snapshot of `bench.sh run` on
+`main` at a point in time, kept for reference. It is *not* used as an automatic CI gate;
+use `compare` against a real base ref (e.g. `origin/main`) for that.
+
+### Fixtures
+
+`benches/gen_fixtures.sh` deterministically generates synthetic FASTQ into `data/`
+(gitignored) - a single-end file and a paired-end pair, uniform-random ACGT bases from a
+fixed-seed PRNG, so the same `BENCH_READS` always produces byte-identical files. It's
+called automatically by `bench.sh run`/`compare` and caches its output
+(`data/meta.env` records the parameters used), so it only regenerates when
+`BENCH_READS`/`READ_LEN` change.
+
+```shell
+BENCH_READS=1000000 benches/gen_fixtures.sh   # default: 1,000,000 single-end reads
+```
+
+Alignment scenarios use the small, already-committed BAM fixtures under
+`tests/cases/` (`test.bam`, `test.paired.bam`) rather than generated data.
+
+### Scenarios
+
+| Scenario         | Command                                                         |
+|-------------------|------------------------------------------------------------------|
+| `reads-num`       | `reads` on generated single-end FASTQ, `-n <count>`               |
+| `reads-frac`      | `reads` on generated single-end FASTQ, `-f 0.25`                  |
+| `reads-coverage`  | `reads` on generated single-end FASTQ, `-c 30 -g <genome size>`   |
+| `reads-paired`    | `reads` on generated paired-end FASTQ, `-n <count>`                |
+| `aln-stream`      | `aln` on `tests/cases/test.bam`, `--strategy stream`               |
+| `aln-fetch`       | `aln` on `tests/cases/test.bam`, `--strategy fetch`                 |
+| `aln-paired`      | `aln` on `tests/cases/test.paired.bam` (paired-end alignment)       |
+
+All scenarios use a fixed `--seed 42` (or `142857` internally for paired fixture
+generation) so results are reproducible run-to-run modulo real timing/memory noise.
+
+### Env vars
+
+| Var                     | Default   | Meaning                                      |
+|--------------------------|-----------|-----------------------------------------------|
+| `BENCH_READS`            | `1000000` | Reads generated for the `reads-*` scenarios   |
+| `BENCH_WARMUP`           | `3`       | Warmup runs before measurement                |
+| `BENCH_RUNS`             | `10`      | Measured runs                                 |
+| `BENCH_WALL_THRESHOLD`   | `1.15`    | `compare` fails if wall-time ratio exceeds this |
+| `BENCH_RSS_THRESHOLD`    | `1.15`    | `compare` fails if peak-RSS ratio exceeds this  |
+
+### Result JSON schema
+
+```jsonc
+{
+  "ref": "origin_main",
+  "commit": "<sha>[+dirty]",
+  "bench_reads": "1000000",
+  "scenarios": {
+    "<scenario-name>": {
+      "wall_mean_s": 0.159,
+      "wall_stddev_s": 0.002,
+      "peak_rss_bytes": 13058048
+    },
+    "...": { }
+  }
+}
+```
+
+## `update_readme.sh`
+
+See the top-level `README.md` [Benchmark](../README.md#benchmark) section for what this
+regenerates and why. Run via the `benchmark.yaml` workflow on release (or
+`workflow_dispatch`); not intended for routine local use since it downloads ~2.9 GB of
+public sequencing data (cached between runs where possible).

--- a/benches/baseline.json
+++ b/benches/baseline.json
@@ -1,0 +1,42 @@
+{
+  "bench_reads": "1000000",
+  "commit": "3694f3453dba6b23692e97c46a58fc0e9db6c726",
+  "ref": "local",
+  "scenarios": {
+    "aln-fetch": {
+      "peak_rss_bytes": 14630912,
+      "wall_mean_s": 1.3183261658199998,
+      "wall_stddev_s": 0.002899039941779387
+    },
+    "aln-paired": {
+      "peak_rss_bytes": 8716288,
+      "wall_mean_s": 0.39462346236000007,
+      "wall_stddev_s": 0.0026262471740279058
+    },
+    "aln-stream": {
+      "peak_rss_bytes": 6242304,
+      "wall_mean_s": 0.42111742828,
+      "wall_stddev_s": 0.001126413602565414
+    },
+    "reads-coverage": {
+      "peak_rss_bytes": 13058048,
+      "wall_mean_s": 0.17606008646000001,
+      "wall_stddev_s": 0.00451791483244252
+    },
+    "reads-frac": {
+      "peak_rss_bytes": 11927552,
+      "wall_mean_s": 0.15787740088000002,
+      "wall_stddev_s": 0.0020511300034965936
+    },
+    "reads-num": {
+      "peak_rss_bytes": 13041664,
+      "wall_mean_s": 0.15763205008,
+      "wall_stddev_s": 0.0015971942069646179
+    },
+    "reads-paired": {
+      "peak_rss_bytes": 6406144,
+      "wall_mean_s": 0.07188619854000002,
+      "wall_stddev_s": 0.0012933027312806583
+    }
+  }
+}

--- a/benches/bench.sh
+++ b/benches/bench.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# A/B benchmark harness for rasusa: wall time + peak RSS per scenario.
+#
+# Usage:
+#   benches/bench.sh run [ref]
+#   benches/bench.sh compare <base> [head]
+#
+#   run [ref]           Build `ref` (a git ref; omit for the current working tree) in
+#                        release mode, run every scenario, write
+#                        benches/results/<ref>.json.
+#   compare <base> [head]
+#                        Run `base` and `head` (head defaults to the current working
+#                        tree) and print wall-time / peak-RSS ratios. Exits non-zero if
+#                        any scenario regressed past the configured thresholds.
+#
+# Env vars:
+#   BENCH_READS         Forwarded to gen_fixtures.sh (default: 1000000)
+#   BENCH_WARMUP        hyperfine/time-loop warmup runs (default: 3)
+#   BENCH_RUNS          hyperfine/time-loop measured runs (default: 10)
+#   BENCH_WALL_THRESHOLD  Regression threshold for wall time ratio (default: 1.15)
+#   BENCH_RSS_THRESHOLD   Regression threshold for peak RSS ratio (default: 1.15)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS_DIR="$REPO_ROOT/benches/results"
+DATA_DIR="${DATA_DIR:-$REPO_ROOT/data}"
+LIB_PY="$REPO_ROOT/benches/lib.py"
+
+WARMUP="${BENCH_WARMUP:-3}"
+RUNS="${BENCH_RUNS:-10}"
+WALL_THRESHOLD="${BENCH_WALL_THRESHOLD:-1.15}"
+RSS_THRESHOLD="${BENCH_RSS_THRESHOLD:-1.15}"
+
+usage() {
+    sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "error: required tool '$1' not found on PATH" >&2
+        exit 1
+    }
+}
+
+sanitize_label() {
+    echo "$1" | tr '/' '_'
+}
+
+ensure_fixtures() {
+    "$REPO_ROOT/benches/gen_fixtures.sh"
+    # shellcheck disable=SC1090
+    source "$DATA_DIR/meta.env"
+}
+
+detect_rss_tool() {
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        if [[ -x /usr/bin/time ]]; then
+            echo "bsd:/usr/bin/time"
+            return
+        fi
+    fi
+    if /usr/bin/time -v true >/dev/null 2>&1; then
+        echo "gnu:/usr/bin/time"
+        return
+    fi
+    if command -v gtime >/dev/null 2>&1 && gtime -v true >/dev/null 2>&1; then
+        echo "gnu:gtime"
+        return
+    fi
+    echo "none"
+}
+
+# Prints peak RSS in bytes for the given command, or nothing if unmeasurable.
+measure_peak_rss_bytes() {
+    local tool="$1"
+    shift
+    case "$tool" in
+    bsd:*)
+        local bin="${tool#bsd:}"
+        ("$bin" -l "$@" 2>&1 1>/dev/null) | awk '/maximum resident set size/ {print $1}'
+        ;;
+    gnu:*)
+        local bin="${tool#gnu:}"
+        ("$bin" -v "$@" 2>&1 1>/dev/null) | awk -F': ' '/Maximum resident set size/ {print $2 * 1024}'
+        ;;
+    *)
+        echo ""
+        ;;
+    esac
+}
+
+# Builds `ref` in release mode and prints the path to the resulting binary.
+# `ref` of "local" (or empty) builds the current working tree in place.
+build_ref() {
+    local ref="$1"
+    if [[ -z "$ref" || "$ref" == "local" ]]; then
+        (cd "$REPO_ROOT" && cargo build --release --bin rasusa --quiet) >&2
+        echo "$REPO_ROOT/target/release/rasusa"
+        return
+    fi
+
+    local label
+    label="$(sanitize_label "$ref")"
+    local wt_dir="$REPO_ROOT/target/bench-worktrees/$label"
+
+    if git -C "$REPO_ROOT" worktree list --porcelain | grep -qx "worktree $wt_dir"; then
+        git -C "$wt_dir" checkout --detach --force --quiet "$ref" >&2
+    else
+        rm -rf "$wt_dir"
+        mkdir -p "$(dirname "$wt_dir")"
+        git -C "$REPO_ROOT" worktree add --detach --quiet "$wt_dir" "$ref" >&2
+    fi
+
+    (cd "$wt_dir" && cargo build --release --bin rasusa --quiet) >&2
+    echo "$wt_dir/target/release/rasusa"
+}
+
+# Prints a shell-quoted command string for the named scenario.
+scenario_cmd_str() {
+    local name="$1" bin="$2"
+    local n=$((META_BENCH_READS / 4))
+    local p=$((META_PAIRED_READS / 2))
+    case "$name" in
+    reads-num)
+        printf '%q ' "$bin" reads "$DATA_DIR/reads.fq" -n "$n" -s 42 -o /dev/null
+        ;;
+    reads-frac)
+        printf '%q ' "$bin" reads "$DATA_DIR/reads.fq" -f 0.25 -s 42 -o /dev/null
+        ;;
+    reads-coverage)
+        printf '%q ' "$bin" reads "$DATA_DIR/reads.fq" -c 30 -g "$META_GENOME_SIZE" -s 42 -o /dev/null
+        ;;
+    reads-paired)
+        printf '%q ' "$bin" reads "$DATA_DIR/r1.fq" "$DATA_DIR/r2.fq" -n "$p" -s 42 -o /dev/null -o /dev/null
+        ;;
+    aln-stream)
+        printf '%q ' "$bin" aln "$REPO_ROOT/tests/cases/test.bam" -c 5 -s 42 --strategy stream -O bam -o /dev/null
+        ;;
+    aln-fetch)
+        printf '%q ' "$bin" aln "$REPO_ROOT/tests/cases/test.bam" -c 5 -s 42 --strategy fetch -O bam -o /dev/null
+        ;;
+    aln-paired)
+        printf '%q ' "$bin" aln "$REPO_ROOT/tests/cases/test.paired.bam" -c 5 -s 42 -O bam -o /dev/null
+        ;;
+    *)
+        echo "unknown scenario: $name" >&2
+        return 1
+        ;;
+    esac
+}
+
+scenario_names() {
+    echo "reads-num reads-frac reads-coverage reads-paired aln-stream aln-fetch aln-paired"
+}
+
+run_one_scenario() {
+    local name="$1" bin="$2" out_json="$3" rss_tool="$4"
+    local cmdstr
+    cmdstr="$(scenario_cmd_str "$name" "$bin")"
+    local -a cmd
+    eval "cmd=( $cmdstr )"
+
+    local mean stddev
+    if command -v hyperfine >/dev/null 2>&1; then
+        local hjson
+        hjson="$(mktemp)"
+        hyperfine --warmup "$WARMUP" --runs "$RUNS" --export-json "$hjson" -- "$cmdstr" >&2
+        read -r mean stddev < <(python3 "$LIB_PY" parse-hyperfine "$hjson")
+        rm -f "$hjson"
+    else
+        read -r mean stddev < <(python3 "$LIB_PY" time-loop "$WARMUP" "$RUNS" "${cmd[@]}")
+    fi
+
+    local rss=""
+    if [[ "$rss_tool" != "none" ]]; then
+        rss="$(measure_peak_rss_bytes "$rss_tool" "${cmd[@]}")"
+    fi
+
+    python3 "$LIB_PY" write-scenario "$out_json" "$name" "$mean" "$stddev" "$rss" >/dev/null
+    echo "    wall_mean=${mean}s peak_rss=${rss:-n/a}" >&2
+}
+
+cmd_run() {
+    local ref="${1:-local}"
+    require python3
+    require cargo
+
+    ensure_fixtures
+    local bin
+    bin="$(build_ref "$ref")"
+
+    local label
+    label="$(sanitize_label "$ref")"
+    mkdir -p "$RESULTS_DIR"
+    local out_json="$RESULTS_DIR/$label.json"
+    rm -f "$out_json"
+
+    local commit
+    if [[ "$ref" == "local" ]]; then
+        commit="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+        # Tracked-file changes only - untracked scratch files in the working tree
+        # shouldn't taint the provenance of an otherwise-clean build.
+        if ! git -C "$REPO_ROOT" diff --quiet HEAD --; then
+            commit="${commit}+dirty"
+        fi
+    else
+        commit="$(git -C "$REPO_ROOT" rev-parse "$ref")"
+    fi
+
+    python3 "$LIB_PY" set-meta "$out_json" ref "$label" >/dev/null
+    python3 "$LIB_PY" set-meta "$out_json" commit "$commit" >/dev/null
+    python3 "$LIB_PY" set-meta "$out_json" bench_reads "$META_BENCH_READS" >/dev/null
+
+    local rss_tool
+    rss_tool="$(detect_rss_tool)"
+    if [[ "$rss_tool" == "none" ]]; then
+        echo "warning: no peak-RSS measurement tool found (need GNU time -v, gtime, or BSD time -l); RSS will be omitted" >&2
+    fi
+
+    for name in $(scenario_names); do
+        echo "==> [$label] $name" >&2
+        run_one_scenario "$name" "$bin" "$out_json" "$rss_tool"
+    done
+
+    echo "$out_json"
+}
+
+cmd_compare() {
+    local base="${1:?compare requires <base> [head]}"
+    local head="${2:-local}"
+
+    local base_json head_json
+    base_json="$(cmd_run "$base")"
+    head_json="$(cmd_run "$head")"
+
+    python3 "$LIB_PY" compare "$base_json" "$head_json" "$WALL_THRESHOLD" "$RSS_THRESHOLD"
+}
+
+main() {
+    local sub="${1:-}"
+    case "$sub" in
+    run)
+        shift
+        cmd_run "$@"
+        ;;
+    compare)
+        shift
+        cmd_compare "$@"
+        ;;
+    -h | --help | help | "")
+        usage
+        ;;
+    *)
+        echo "error: unknown subcommand '$sub'" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+}
+
+main "$@"

--- a/benches/gen_fixtures.sh
+++ b/benches/gen_fixtures.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Deterministically generate synthetic FASTQ fixtures for the benchmark harness.
+#
+# Usage: benches/gen_fixtures.sh
+#
+# Env vars:
+#   BENCH_READS  - number of single-end reads to generate (default: 1000000)
+#   READ_LEN     - length (bp) of each generated read (default: 150)
+#   DATA_DIR     - output directory (default: <repo>/data)
+#
+# Output is a deterministic function of BENCH_READS and READ_LEN alone (fixed internal
+# seed), so regenerating with the same values produces byte-identical files. Files are
+# cached and only regenerated if those values change or files are missing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BENCH_READS="${BENCH_READS:-1000000}"
+READ_LEN="${READ_LEN:-150}"
+DATA_DIR="${DATA_DIR:-$REPO_ROOT/data}"
+
+READS_FQ="$DATA_DIR/reads.fq"
+R1_FQ="$DATA_DIR/r1.fq"
+R2_FQ="$DATA_DIR/r2.fq"
+META="$DATA_DIR/meta.env"
+
+mkdir -p "$DATA_DIR"
+
+if [[ -f "$META" ]]; then
+    # shellcheck disable=SC1090
+    source "$META"
+    if [[ "${META_BENCH_READS:-}" == "$BENCH_READS" && "${META_READ_LEN:-}" == "$READ_LEN" \
+        && -f "$READS_FQ" && -f "$R1_FQ" && -f "$R2_FQ" ]]; then
+        echo "[gen_fixtures] cached fixtures for BENCH_READS=$BENCH_READS READ_LEN=$READ_LEN already exist in $DATA_DIR" >&2
+        exit 0
+    fi
+fi
+
+echo "[gen_fixtures] generating fixtures for BENCH_READS=$BENCH_READS READ_LEN=$READ_LEN into $DATA_DIR" >&2
+
+PAIRED_READS=$(( BENCH_READS / 5 ))
+if [[ "$PAIRED_READS" -lt 2 ]]; then
+    PAIRED_READS=2
+fi
+
+# Both the single-end and paired-end sets are generated in one awk process, sharing the
+# same PRNG/sequence-generation functions (a Park-Miller LCG seeded with fixed
+# constants, so output only depends on BENCH_READS/READ_LEN/PAIRED_READS, never on the
+# host's random source or awk implementation's built-in rand()). Each set reseeds `state`
+# independently so they don't affect each other.
+awk -v n="$BENCH_READS" -v pn="$PAIRED_READS" -v len="$READ_LEN" \
+    -v seed1=42 -v seed2=142857 \
+    -v out="$READS_FQ" -v out1="$R1_FQ" -v out2="$R2_FQ" '
+function rnd() {
+    state = (state * 48271) % 2147483647
+    return state / 2147483647
+}
+function randseq(   seq, j, idx) {
+    seq = ""
+    for (j = 0; j < len; j++) {
+        idx = int(rnd() * 4) + 1
+        seq = seq substr(bases, idx, 1)
+    }
+    return seq
+}
+BEGIN {
+    bases = "ACGT"
+    qual = sprintf("%*s", len, "")
+    gsub(/ /, "I", qual)
+
+    state = seed1
+    for (i = 0; i < n; i++) {
+        printf "@read%d\n%s\n+\n%s\n", i, randseq(), qual > out
+    }
+
+    state = seed2
+    for (i = 0; i < pn; i++) {
+        printf "@pair%d/1\n%s\n+\n%s\n", i, randseq(), qual > out1
+        printf "@pair%d/2\n%s\n+\n%s\n", i, randseq(), qual > out2
+    }
+}'
+
+TOTAL_BASES=$(( BENCH_READS * READ_LEN ))
+# Pick a genome size such that a 30x coverage target uses well under the total bases
+# generated, so the `reads-coverage` scenario is always satisfiable.
+GENOME_SIZE=$(( TOTAL_BASES / 60 ))
+
+cat > "$META" << EOF
+META_BENCH_READS=$BENCH_READS
+META_READ_LEN=$READ_LEN
+META_TOTAL_BASES=$TOTAL_BASES
+META_GENOME_SIZE=$GENOME_SIZE
+META_PAIRED_READS=$PAIRED_READS
+EOF
+
+echo "[gen_fixtures] done: $BENCH_READS single-end reads ($TOTAL_BASES bp), $PAIRED_READS read pairs" >&2

--- a/benches/lib.py
+++ b/benches/lib.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""JSON I/O and comparison helpers for benches/bench.sh.
+
+Not meant to be run directly by humans - it's a small dispatch table of subcommands
+bench.sh shells out to, so bench.sh doesn't need to hand-roll JSON parsing/formatting
+in bash.
+"""
+import json
+import subprocess
+import sys
+import time
+
+
+def _load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"scenarios": {}}
+
+
+def _dump(path, data):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def cmd_write_scenario(args):
+    # write-scenario <result.json> <scenario> <wall_mean_s> <wall_stddev_s> <peak_rss_bytes|"">
+    path, scenario, wall_mean, wall_stddev, rss = args
+    data = _load(path)
+    data.setdefault("scenarios", {})[scenario] = {
+        "wall_mean_s": float(wall_mean),
+        "wall_stddev_s": float(wall_stddev),
+        "peak_rss_bytes": int(float(rss)) if rss not in ("", "null") else None,
+    }
+    _dump(path, data)
+
+
+def cmd_set_meta(args):
+    # set-meta <result.json> <key> <value>
+    path, key, value = args
+    data = _load(path)
+    data[key] = value
+    _dump(path, data)
+
+
+def cmd_parse_hyperfine(args):
+    # parse-hyperfine <hyperfine-export.json>  -> prints "<mean> <stddev>"
+    (path,) = args
+    with open(path) as f:
+        data = json.load(f)
+    r = data["results"][0]
+    print(r["mean"], r["stddev"])
+
+
+def cmd_time_loop(args):
+    # time-loop <warmup> <runs> <cmd...>  -> prints "<mean> <stddev>"
+    warmup = int(args[0])
+    runs = int(args[1])
+    cmd = args[2:]
+    for _ in range(warmup):
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    times = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        times.append(time.perf_counter() - t0)
+    mean = sum(times) / len(times)
+    variance = sum((t - mean) ** 2 for t in times) / len(times)
+    print(mean, variance**0.5)
+
+
+def cmd_compare(args):
+    # compare <base.json> <head.json> <wall_threshold> <rss_threshold>
+    base_path, head_path, wall_threshold, rss_threshold = args
+    wall_threshold = float(wall_threshold)
+    rss_threshold = float(rss_threshold)
+    base = _load(base_path)
+    head = _load(head_path)
+
+    base_scn = base.get("scenarios", {})
+    head_scn = head.get("scenarios", {})
+    names = sorted(set(base_scn) | set(head_scn))
+
+    header = (
+        "scenario",
+        "base wall(s)",
+        "head wall(s)",
+        "wall ratio",
+        "base RSS(MB)",
+        "head RSS(MB)",
+        "RSS ratio",
+    )
+    rows = [header]
+    regressed = []
+
+    for name in names:
+        b = base_scn.get(name)
+        h = head_scn.get(name)
+        if not b or not h:
+            rows.append((name, "missing", "-", "-", "-", "-", "-"))
+            continue
+
+        wall_ratio = h["wall_mean_s"] / b["wall_mean_s"] if b["wall_mean_s"] else float("nan")
+
+        rss_ratio = None
+        if b.get("peak_rss_bytes") and h.get("peak_rss_bytes"):
+            rss_ratio = h["peak_rss_bytes"] / b["peak_rss_bytes"]
+
+        rows.append((
+            name,
+            f"{b['wall_mean_s']:.3f}",
+            f"{h['wall_mean_s']:.3f}",
+            f"{wall_ratio:.2f}",
+            f"{b['peak_rss_bytes'] / 1e6:.1f}" if b.get("peak_rss_bytes") else "-",
+            f"{h['peak_rss_bytes'] / 1e6:.1f}" if h.get("peak_rss_bytes") else "-",
+            f"{rss_ratio:.2f}" if rss_ratio is not None else "-",
+        ))
+
+        if wall_ratio > wall_threshold:
+            regressed.append(f"{name}: wall time {wall_ratio:.2f}x base (threshold {wall_threshold}x)")
+        if rss_ratio is not None and rss_ratio > rss_threshold:
+            regressed.append(f"{name}: peak RSS {rss_ratio:.2f}x base (threshold {rss_threshold}x)")
+
+    widths = [max(len(str(r[i])) for r in rows) for i in range(len(header))]
+
+    def fmt_row(r):
+        return "  ".join(str(v).ljust(widths[i]) for i, v in enumerate(r))
+
+    print(fmt_row(rows[0]))
+    print("  ".join("-" * w for w in widths))
+    for r in rows[1:]:
+        print(fmt_row(r))
+
+    if regressed:
+        print("\nREGRESSIONS DETECTED:", file=sys.stderr)
+        for line in regressed:
+            print(f"  - {line}", file=sys.stderr)
+        sys.exit(1)
+
+
+COMMANDS = {
+    "write-scenario": cmd_write_scenario,
+    "set-meta": cmd_set_meta,
+    "parse-hyperfine": cmd_parse_hyperfine,
+    "time-loop": cmd_time_loop,
+    "compare": cmd_compare,
+}
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
+        print(f"usage: {sys.argv[0]} <{'|'.join(COMMANDS)}> [args...]", file=sys.stderr)
+        sys.exit(2)
+    COMMANDS[sys.argv[1]](sys.argv[2:])
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/render_readme.py
+++ b/benches/render_readme.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Helpers for benches/update_readme.sh: render benchmark blocks and splice them into
+README.md between the `<!-- BENCH:<name>:START/END -->` markers.
+"""
+import json
+import re
+import sys
+
+
+def _relative_str(mean, stddev, fastest_mean, fastest_stddev, with_stddev=True):
+    ratio = mean / fastest_mean
+    if with_stddev:
+        rel_err = ratio * ((stddev / mean) ** 2 + (fastest_stddev / fastest_mean) ** 2) ** 0.5
+        return f"{ratio:.2f} ± {rel_err:.2f}"
+    return f"{ratio:.2f}"
+
+
+def _load_results(json_path):
+    with open(json_path) as f:
+        return json.load(f)["results"]
+
+
+def _read_table(md_path):
+    with open(md_path) as f:
+        return f.read().rstrip("\n")
+
+
+def cmd_single_block(args):
+    md_path, json_path = args
+    results = _load_results(json_path)
+    rasusa = next(r for r in results if "rasusa" in r["command"])
+    other = next(r for r in results if r is not rasusa)
+
+    table = _read_table(md_path)
+    relative = _relative_str(other["mean"], other["stddev"], rasusa["mean"], rasusa["stddev"])
+    print(table)
+    print()
+    print(f"**Summary**: `rasusa` ran {relative} times faster than `filtlong`.")
+
+
+def cmd_paired_block(args):
+    md_path, json_path = args
+    results = _load_results(json_path)
+    rasusa = next(r for r in results if "rasusa" in r["command"])
+    others = [r for r in results if r is not rasusa]
+    # Order: 1-pass seqtk, 2-pass seqtk, matching the hyperfine invocation order.
+    ratio1 = _relative_str(others[0]["mean"], others[0]["stddev"], rasusa["mean"], rasusa["stddev"], with_stddev=False)
+    ratio2 = _relative_str(others[1]["mean"], others[1]["stddev"], rasusa["mean"], rasusa["stddev"], with_stddev=False)
+
+    table = _read_table(md_path)
+    print(table)
+    print()
+    print(
+        f"**Summary**: `rasusa reads` ran {ratio1} times faster than `seqtk` (1-pass) "
+        f"and {ratio2} times faster than `seqtk` (2-pass)"
+    )
+
+
+def cmd_splice(args):
+    readme_path, marker, content_path = args
+    with open(readme_path) as f:
+        readme = f.read()
+    with open(content_path) as f:
+        content = f.read().rstrip("\n")
+
+    start = f"<!-- BENCH:{marker}:START -->"
+    end = f"<!-- BENCH:{marker}:END -->"
+    pattern = re.compile(re.escape(start) + r".*?" + re.escape(end), re.DOTALL)
+    if not pattern.search(readme):
+        print(f"error: markers {start!r}/{end!r} not found in {readme_path}", file=sys.stderr)
+        sys.exit(1)
+
+    replacement = f"{start}\n{content}\n{end}"
+    readme = pattern.sub(lambda _: replacement, readme, count=1)
+    with open(readme_path, "w") as f:
+        f.write(readme)
+
+
+COMMANDS = {
+    "single-block": cmd_single_block,
+    "paired-block": cmd_paired_block,
+    "splice": cmd_splice,
+}
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
+        print(f"usage: {sys.argv[0]} <{'|'.join(COMMANDS)}> [args...]", file=sys.stderr)
+        sys.exit(2)
+    COMMANDS[sys.argv[1]](sys.argv[2:])
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/update_readme.sh
+++ b/benches/update_readme.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Regenerates the top-level README's tool-comparison benchmark tables (rasusa vs
+# filtlong/seqtk) and splices them between the `<!-- BENCH:*:START/END -->` markers.
+#
+# Downloads two real public sequencing datasets on first run (~2.9 GB total) and caches
+# them under data/download-cache/ (override with BENCH_DOWNLOAD_CACHE). Intended to run
+# from .github/workflows/benchmark.yaml on release; not routine local use.
+#
+# Requires on PATH: hyperfine, filtlong, seqtk, fastaq, wget, python3, cargo (unless
+# RASUSA_BIN is set to a prebuilt binary). filtlong/seqtk/fastaq are available via
+# bioconda: `conda install -c bioconda filtlong seqtk fastaq`.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+README="$REPO_ROOT/README.md"
+CACHE_DIR="${BENCH_DOWNLOAD_CACHE:-$REPO_ROOT/data/download-cache}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir -p "$CACHE_DIR"
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "error: required tool '$1' not found on PATH" >&2
+        exit 1
+    }
+}
+require hyperfine
+require filtlong
+require seqtk
+require fastaq
+require wget
+require python3
+
+if [[ -z "${RASUSA_BIN:-}" ]]; then
+    echo "[update_readme] building rasusa --release..." >&2
+    require cargo
+    (cd "$REPO_ROOT" && cargo build --release --bin rasusa --quiet)
+    RASUSA_BIN="$REPO_ROOT/target/release/rasusa"
+fi
+[[ -x "$RASUSA_BIN" ]] || {
+    echo "error: RASUSA_BIN '$RASUSA_BIN' is not an executable" >&2
+    exit 1
+}
+
+### Single long-read input (rasusa vs filtlong) ###
+
+TB_FQ="$CACHE_DIR/tb.fq"
+if [[ ! -f "$TB_FQ" ]]; then
+    echo "[update_readme] downloading single long-read dataset..." >&2
+    URL="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR649/008/SRR6490088/SRR6490088_1.fastq.gz"
+    wget -q "$URL" -O - | gzip -d -c > "$TB_FQ"
+else
+    echo "[update_readme] using cached $TB_FQ" >&2
+fi
+
+TB_GENOME_SIZE=4411532
+COVG=50
+TARGET_BASES=$((TB_GENOME_SIZE * COVG))
+FILTLONG_CMD="filtlong --target_bases $TARGET_BASES $TB_FQ"
+RASUSA_CMD="$RASUSA_BIN reads $TB_FQ -c $COVG -g $TB_GENOME_SIZE -s 1 -o /dev/null"
+
+echo "[update_readme] running single-input benchmark..." >&2
+hyperfine --warmup 3 --runs 10 \
+    --export-markdown "$WORK_DIR/single.md" --export-json "$WORK_DIR/single.json" \
+    "$FILTLONG_CMD" "$RASUSA_CMD"
+
+python3 "$REPO_ROOT/benches/render_readme.py" single-block "$WORK_DIR/single.md" "$WORK_DIR/single.json" > "$WORK_DIR/single-block.md"
+python3 "$REPO_ROOT/benches/render_readme.py" splice "$README" single "$WORK_DIR/single-block.md"
+
+### Paired-end input (rasusa vs seqtk) ###
+
+R1_FQ="$CACHE_DIR/r1.fq"
+R2_FQ="$CACHE_DIR/r2.fq"
+if [[ ! -f "$R1_FQ" || ! -f "$R2_FQ" ]]; then
+    echo "[update_readme] downloading paired-end dataset..." >&2
+    URL="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR648/008/SRR6488968/SRR6488968.fastq.gz"
+    wget -q "$URL" -O - | gzip -d -c - | fastaq deinterleave - "$R1_FQ" "$R2_FQ"
+else
+    echo "[update_readme] using cached $R1_FQ / $R2_FQ" >&2
+fi
+
+NUM_READS=140000
+SEQTK_CMD_1="seqtk sample -s 1 $R1_FQ $NUM_READS > $WORK_DIR/o1.fq; seqtk sample -s 1 $R2_FQ $NUM_READS > $WORK_DIR/o2.fq;"
+SEQTK_CMD_2="seqtk sample -2 -s 1 $R1_FQ $NUM_READS > $WORK_DIR/o1.fq; seqtk sample -2 -s 1 $R2_FQ $NUM_READS > $WORK_DIR/o2.fq;"
+RASUSA_CMD="$RASUSA_BIN reads $R1_FQ $R2_FQ -n $NUM_READS -s 1 -o $WORK_DIR/o1.fq -o $WORK_DIR/o2.fq"
+
+echo "[update_readme] running paired-input benchmark..." >&2
+hyperfine --warmup 10 --runs 100 \
+    --export-markdown "$WORK_DIR/paired.md" --export-json "$WORK_DIR/paired.json" \
+    "$SEQTK_CMD_1" "$SEQTK_CMD_2" "$RASUSA_CMD"
+
+python3 "$REPO_ROOT/benches/render_readme.py" paired-block "$WORK_DIR/paired.md" "$WORK_DIR/paired.json" > "$WORK_DIR/paired-block.md"
+python3 "$REPO_ROOT/benches/render_readme.py" splice "$README" paired "$WORK_DIR/paired-block.md"
+
+echo "[update_readme] README.md benchmark tables updated" >&2


### PR DESCRIPTION
## Summary
- Adds `benches/bench.sh` (`run [ref]` / `compare <base> [head]`) - an A/B harness measuring wall time (hyperfine, with a portable fallback) and peak RSS across 7 scenarios (`reads` num/frac/coverage/paired, `aln` stream/fetch/paired), exiting non-zero on regression past a configurable threshold.
- Adds `benches/gen_fixtures.sh` - deterministic synthetic FASTQ generation for the `reads` scenarios (real committed BAM fixtures are reused for `aln`).
- Adds `benches/update_readme.sh` + `.github/workflows/benchmark.yaml` - regenerates the README's rasusa-vs-filtlong/seqtk comparison tables (now marker-delimited) on release/dispatch/monthly schedule and commits them back.
- Commits `benches/baseline.json` as a reference snapshot and `benches/README.md` documenting usage.

Closes #171 (part of the #170 umbrella).

Internal tooling only - no `src/` changes, no user-facing behavior change (hence `ci(bench)` rather than `feat`, per #171's own "Release: ci/chore (no release)" note).

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (incl. `reproducibility_reads_seeds_1_to_5` / `reproducibility_aln_seed_42`, unchanged) all pass
- [x] `benches/bench.sh run local` produces JSON with all 7 scenarios
- [x] `benches/bench.sh compare origin/main origin/main` → ≈1.00 ratios, exit 0
- [x] Forced-threshold test confirms regression detection exits non-zero
- [x] `render_readme.py`'s marker-splice logic verified idempotent against synthetic hyperfine output matching the exact original README table format