### PR TITLE
refactor(lib): S2 · Extract src/lib.rs library target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +234,33 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -292,6 +337,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,10 +379,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -331,6 +434,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
@@ -410,6 +519,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +576,17 @@ dependencies = [
  "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -491,6 +635,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +681,17 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -864,10 +1028,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -987,6 +1191,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "criterion",
  "env_logger",
  "log",
  "needletail",
@@ -1000,6 +1205,26 @@ dependencies = [
  "regex",
  "tempfile",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1042,6 +1267,21 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1115,6 +1355,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -1193,6 +1439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1488,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1513,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1281,6 +1592,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1393,6 +1723,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ noodles-bgzf = { version = "0.46.0", features = ["libdeflate"] }
 assert_cmd = "2.2.0"
 predicates = "3.1.4"
 tempfile = "3.27.0"
+criterion = "0.7"
+
+[[bench]]
+name = "subsample"
+harness = false
 
 [profile.release]
 strip = true   # https://github.com/johnthagen/min-sized-rust?tab=readme-ov-file#strip-symbols-from-binary

--- a/benches/subsample.rs
+++ b/benches/subsample.rs
@@ -1,0 +1,31 @@
+//! Micro-benchmark for `SubSampler::indices` in `--num`/`--frac` (num_reads) mode -
+//! the selection algorithm S10 replaces with an O(k) approach. This guards against
+//! algorithmic regressions independent of I/O, unlike `benches/bench.sh`'s end-to-end
+//! scenarios.
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use rasusa::SubSampler;
+use std::hint::black_box;
+
+fn bench_indices_num_reads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SubSampler::indices (num_reads)");
+
+    for &n in &[1_000usize, 100_000, 1_000_000] {
+        let lengths: Vec<u32> = vec![150; n];
+        for &frac in &[0.01f64, 0.5] {
+            let k = ((n as f64) * frac) as u64;
+            let sampler = SubSampler {
+                target_total_bases: None,
+                seed: Some(42),
+                num_reads: Some(k),
+            };
+            group.bench_function(BenchmarkId::new(format!("n={n}"), k), |b| {
+                b.iter(|| black_box(&sampler).indices(black_box(&lengths)));
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_indices_num_reads);
+criterion_main!(benches);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,7 @@ pub struct Cli {
     pub verbose: bool,
 
     #[command(subcommand)]
-    pub(crate) command: Commands,
+    pub command: Commands,
 }
 
 #[derive(Subcommand, Debug)]
@@ -148,7 +148,10 @@ impl FromStr for MetricSuffix {
     /// Parses a string into a `MetricSuffix`.
     ///
     /// # Example
-    /// ```rust
+    // TODO(S9): stale doctest - `MetricSuffix` is private, so it isn't reachable from
+    // an external doctest, and `metric_suffix` is a `Result` here, not a bare
+    // `MetricSuffix`. Fix or rewrite as a unit test in the S9 doctest/test cleanup pass.
+    /// ```rust,ignore
     /// let s = "5.5mb";
     /// let metric_suffix = MetricSuffix::from_str(s);
     ///
@@ -174,7 +177,10 @@ impl FromStr for MetricSuffix {
 ///
 /// # Example
 ///
-/// ```rust
+// TODO(S9): stale doctest - `MetricSuffix` is private, so it isn't reachable from an
+// external doctest, and the result is an `f64` compared against an integer literal.
+// Fix or rewrite as a unit test in the S9 doctest/test cleanup pass.
+/// ```rust,ignore
 /// let metric_suffix = MetricSuffix::Mega;
 /// let x: f64 = 5.5;
 ///
@@ -203,7 +209,10 @@ pub struct GenomeSize(u64);
 ///
 /// # Example
 ///
-/// ```rust
+// TODO(S9): stale doctest - `GenomeSize`'s inner field is private, so it can't be
+// constructed from an external doctest. Fix or rewrite as a unit test in the S9
+// doctest/test cleanup pass.
+/// ```rust,ignore
 /// assert!(GenomeSize(10) == 10)
 /// ```
 impl PartialEq<u64> for GenomeSize {
@@ -231,7 +240,10 @@ impl FromStr for GenomeSize {
     /// Parses a string into a `GenomeSize`.
     ///
     /// # Example
-    /// ```rust
+    // TODO(S9): stale doctest - `GenomeSize`'s inner field is private (can't construct
+    // it from an external doctest), and `genome_size` is a `Result` here, not a bare
+    // `GenomeSize`. Fix or rewrite as a unit test in the S9 doctest/test cleanup pass.
+    /// ```rust,ignore
     /// let s = "5.5mb";
     /// let genome_size = GenomeSize::from_str(s);
     ///
@@ -286,7 +298,10 @@ impl GenomeSize {
 ///
 /// # Example
 ///
-/// ```rust
+// TODO(S9): stale doctest - `GenomeSize`'s inner field is private, so it can't be
+// constructed from an external doctest. Fix or rewrite as a unit test in the S9
+// doctest/test cleanup pass.
+/// ```rust,ignore
 /// let genome_size = GenomeSize(100);
 /// let covg = Coverage(5);
 ///
@@ -304,7 +319,10 @@ impl Mul<Coverage> for GenomeSize {
 ///
 /// # Example
 ///
-/// ```rust
+// TODO(S9): stale doctest - `GenomeSize`'s inner field is private, so it can't be
+// constructed from an external doctest. Fix or rewrite as a unit test in the S9
+// doctest/test cleanup pass.
+/// ```rust,ignore
 /// let x: u64 = 210;
 /// let size = GenomeSize(200);
 ///
@@ -331,7 +349,9 @@ pub struct Coverage(pub f32);
 /// # Example
 ///
 /// ```rust
-/// assert!(Coverage(10) == 10.0)
+/// use rasusa::cli::Coverage;
+///
+/// assert!(Coverage(10.0) == 10.0)
 /// ```
 impl PartialEq<f32> for Coverage {
     fn eq(&self, other: &f32) -> bool {
@@ -346,10 +366,13 @@ impl FromStr for Coverage {
     ///
     /// # Example
     /// ```rust
-    /// let s = "100x";
-    /// let covg = Coverage::from_str(s);
+    /// use rasusa::cli::Coverage;
+    /// use std::str::FromStr;
     ///
-    /// assert_eq!(covg, Coverage(100))
+    /// let s = "100x";
+    /// let covg = Coverage::from_str(s).unwrap();
+    ///
+    /// assert_eq!(covg, Coverage(100.0))
     /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let re = Regex::new(r"^(?P<covg>[0-9]*\.?[0-9]+)(?i)x?$")
@@ -375,7 +398,10 @@ impl FromStr for Coverage {
 ///
 /// # Example
 ///
-/// ```rust
+// TODO(S9): stale doctest - `GenomeSize`'s inner field is private, so it can't be
+// constructed from an external doctest. Fix or rewrite as a unit test in the S9
+// doctest/test cleanup pass.
+/// ```rust,ignore
 /// let covg = Coverage(5);
 /// let genome_size = GenomeSize(100);
 ///

--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -60,6 +60,8 @@ impl Fastx {
     /// # Example
     ///
     /// ```rust
+    /// use rasusa::fastx::Fastx;
+    ///
     /// let path = std::path::Path::new("input.fa.gz");
     /// let fastx = Fastx::from_path(path);
     /// ```
@@ -80,8 +82,8 @@ impl RecordSource for Fastx {
     /// # Example
     ///
     /// ```rust
-    /// use crate::fastx::Fastx;
-    /// use crate::source::RecordSource;
+    /// use rasusa::fastx::Fastx;
+    /// use rasusa::source::RecordSource;
     /// use std::io::Write;
     /// let text = "@read1\nACGT\n+\n!!!!\n@read2\nG\n+\n!";
     /// let mut file = tempfile::Builder::new().suffix(".fq").tempfile().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,20 @@
+#![allow(clippy::redundant_clone)]
+
+extern crate core;
+
+use anyhow::Result;
+
+pub mod alignment;
+pub mod cli;
+pub mod fastx;
+pub mod reads;
+pub mod source;
+pub mod subsampler;
+
+pub use crate::cli::Cli;
+pub use crate::fastx::Fastx;
+pub use crate::subsampler::SubSampler;
+
+pub trait Runner {
+    fn run(&mut self) -> Result<()>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,10 @@
-#![allow(clippy::redundant_clone)]
-
-extern crate core;
-
 use anyhow::Result;
 use clap::Parser;
 use env_logger::Builder;
 use log::{debug, LevelFilter};
 
-pub use crate::cli::Cli;
-use crate::cli::Commands;
-pub use crate::fastx::Fastx;
-pub use crate::subsampler::SubSampler;
-
-mod alignment;
-mod cli;
-mod fastx;
-mod reads;
-mod source;
-mod subsampler;
-
-pub trait Runner {
-    fn run(&mut self) -> Result<()>;
-}
+use rasusa::cli::{Cli, Commands};
+use rasusa::Runner;
 
 fn main() -> Result<()> {
     let args: Cli = Cli::parse();

--- a/src/subsampler.rs
+++ b/src/subsampler.rs
@@ -22,7 +22,10 @@ impl SubSampler {
     ///
     /// # Example
     ///
-    /// ```rust
+    // TODO(S9): stale doctest - `shuffled_indices` is private (can't be called from an
+    // external doctest) and the struct literal is missing `num_reads`. Fix or rewrite
+    // as a unit test in the S9 doctest/test cleanup pass.
+    /// ```rust,ignore
     /// let v: Vec<u64> = vec![55, 1];
     /// let sampler = SubSampler {
     ///     target_total_bases: 100,
@@ -60,7 +63,10 @@ impl SubSampler {
     ///
     /// # Example
     ///
-    /// ```rust
+    // TODO(S9): stale doctest - struct literal is missing `num_reads`, and `indices`
+    // returns `(Vec<bool>, usize)`, not a directly-indexable collection. Fix or rewrite
+    // as a unit test in the S9 doctest/test cleanup pass.
+    /// ```rust,ignore
     /// let v: Vec<u32> = vec![50, 50, 50];
     /// let sampler = SubSampler {
     ///     target_total_bases: 100,


### PR DESCRIPTION
## Summary
- Adds `src/lib.rs`, re-exporting `cli`, `reads`, `alignment`, `subsampler`, `source`, `fastx`, and the `Runner` trait.
- Reduces `src/main.rs` to a thin binary (CLI parsing + logging + dispatch) calling `rasusa::…`. Confirmed byte-identical logic to before.
- Widens `Cli.command` from `pub(crate)` to `pub` (the minimum needed for `main.rs` to read it as a separate crate now).
- Adds a criterion scaffold: `criterion` dev-dependency, `[[bench]] name = "subsample"`, and `benches/subsample.rs` benchmarking `SubSampler::indices` in num-reads mode across (n, k) - a micro-guard for the O(k) selection change in S10 (#180).
- `cargo test --doc` now actually runs doctests for the first time (previously invisible on a bin-only crate). Of 13: 4 had simple import/assertion bugs, fixed here; the other 9 reference private types/fields unreachable from an external doctest, or need behavior changes out of scope for this step - each is marked `` ```rust,ignore `` with a `TODO(S9)` comment explaining exactly why, deferring to #179.

No behavior or CLI change.

Closes #172 (part of the #170 umbrella).

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` pass clean
- [x] `cargo test --all-targets` passes in full (147+27+2+1 tests, incl. `reproducibility_reads_seeds_1_to_5`/`reproducibility_aln_seed_42` unchanged)
- [x] `cargo test --doc` runs 13 doctests: 4 pass, 9 correctly `ignore`d
- [x] `cargo bench --no-run` compiles; `cargo bench --bench subsample` runs successfully
- [x] Manually confirmed `main.rs`'s dispatch logic is unchanged (diffed against `HEAD:src/main.rs`)