### PR TITLE
perf(reads): buffer stdout output on the reads path (S3)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,5 +5,18 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false
     }
-  }
+  },
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ]
 }

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use log::{debug, error, info, warn};
 use niffler::compression;
-use std::io::stdout;
+use std::io::{stdout, BufWriter};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Parser)]
@@ -201,7 +201,7 @@ impl Runner for Reads {
 
         let mut output_handle = match self.output.len() {
             0 => match self.compress_type {
-                None => Box::new(stdout()) as Box<dyn std::io::Write>,
+                None => Box::new(BufWriter::new(stdout().lock())) as Box<dyn std::io::Write>,
                 Some(fmt) => {
                     let lvl = match fmt {
                         compression::Format::Gzip => compression::Level::Six,
@@ -210,7 +210,7 @@ impl Runner for Reads {
                         compression::Format::Zstd => compression::Level::Three,
                         _ => compression::Level::Zero,
                     };
-                    niffler::basic::get_writer(Box::new(stdout()), fmt, lvl)?
+                    niffler::basic::get_writer(Box::new(BufWriter::new(stdout().lock())), fmt, lvl)?
                 }
             },
             _ => create_output_writer(&self.output[0], self.compress_level, self.compress_type)
@@ -256,10 +256,11 @@ impl Runner for Reads {
         }
         info!("{} reads detected", read_lengths.len());
 
+        let total_input_bases: u64 = read_lengths.iter().map(|&x| x as u64).sum();
+
         // calculate the depth of coverage if using coverage-based subsampling
         if let Some(size) = self.genome_size {
-            let number_of_bases: u64 = read_lengths.iter().map(|&x| x as u64).sum();
-            let depth_of_covg = (number_of_bases as f64) / f64::from(size);
+            let depth_of_covg = (total_input_bases as f64) / f64::from(size);
             info!("Input coverage is {:.2}x", depth_of_covg);
 
             if self.strict
@@ -275,13 +276,12 @@ impl Runner for Reads {
         }
 
         if let Some(req_bases) = self.bases {
-            let total_bases: u64 = read_lengths.iter().map(|&x| x as u64).sum();
             let req_bases = u64::from(req_bases);
-            if self.strict && req_bases > total_bases {
+            if self.strict && req_bases > total_input_bases {
                 return Err(anyhow::anyhow!(
                     "Requested number of bases ({}) is more than the input ({})",
                     req_bases,
-                    total_bases
+                    total_input_bases
                 ));
             }
         }
@@ -333,7 +333,16 @@ impl Runner for Reads {
         } else {
             info!("Keeping {} reads", nb_reads_to_keep);
         }
-        debug!("Indices of reads being kept:\n{:?}", reads_to_keep);
+        const DEBUG_MAX_LOGGED_INDICES: usize = 10_000;
+        if reads_to_keep.len() <= DEBUG_MAX_LOGGED_INDICES {
+            debug!("Indices of reads being kept:\n{:?}", reads_to_keep);
+        } else {
+            debug!(
+                "Indices of reads being kept: omitted ({} reads exceeds debug print cap of {})",
+                reads_to_keep.len(),
+                DEBUG_MAX_LOGGED_INDICES
+            );
+        }
 
         let output_format_1 = match &self.output_format {
             Some(crate::cli::OutputFormat::Sam) => Some(noodles_util::alignment::io::Format::Sam),


### PR DESCRIPTION
## Summary
- Wraps the stdout sink in `BufWriter` over `stdout().lock()` for both the compressed and uncompressed output arms in `src/reads.rs`, matching the buffering already used for file output.
- Quick-wins: sum read lengths once (`total_input_bases`) instead of twice, and cap the full-mask `debug!` log of kept-read indices at 10,000 so `-v` doesn't format huge vectors.
- Pins explicit `changelog-sections` in `.release-please-config.json` so `perf` (and this repo's other `cog.toml` commit types) reliably surface in `CHANGELOG.md`, rather than relying on release-please's undeclared built-in defaults.

Closes #173

## Test plan
- [x] `cargo build` / `cargo build --release`
- [x] `cargo fmt` / `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` (unit + integration + doctests) all pass
- [x] Manual smoke test: `rasusa reads -n 2 -s 1 mini.fq > mini.out.fq` produces correct, fully-flushed output
- [x] Two-axis code review (Standards + Spec) run against the diff; addressed the one naming nit raised