### PR TITLE
fix(reads): testable seam + remove panic/exit hazards (S4)

### DIFF
--- a/benches/subsample.rs
+++ b/benches/subsample.rs
@@ -3,23 +3,21 @@
 //! algorithmic regressions independent of I/O, unlike `benches/bench.sh`'s end-to-end
 //! scenarios.
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use rasusa::SubSampler;
+use rasusa::{SubSampler, SubsampleMode};
 use std::hint::black_box;
 
 fn bench_indices_num_reads(c: &mut Criterion) {
     let mut group = c.benchmark_group("SubSampler::indices (num_reads)");
 
     for &n in &[1_000usize, 100_000, 1_000_000] {
-        let lengths: Vec<u32> = vec![150; n];
         for &frac in &[0.01f64, 0.5] {
             let k = ((n as f64) * frac) as u64;
             let sampler = SubSampler {
-                target_total_bases: None,
+                mode: SubsampleMode::ByReads(k),
                 seed: Some(42),
-                num_reads: Some(k),
             };
             group.bench_function(BenchmarkId::new(format!("n={n}"), k), |b| {
-                b.iter(|| black_box(&sampler).indices(black_box(&lengths)));
+                b.iter(|| black_box(&sampler).indices(black_box(n), black_box(&[])));
             });
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -287,7 +287,10 @@ impl GenomeSize {
             let line =
                 result.map_err(|_| CliError::FaidxError(path.to_string_lossy().to_string()))?;
             let fields: Vec<&str> = line.split('\t').collect();
-            size += u64::from_str(fields[1])
+            let length_field = fields
+                .get(1)
+                .ok_or_else(|| CliError::FaidxError(path.to_string_lossy().to_string()))?;
+            size += u64::from_str(length_field)
                 .map_err(|_| CliError::FaidxError(path.to_string_lossy().to_string()))?;
         }
         Ok(GenomeSize(size))
@@ -725,6 +728,19 @@ pub(crate) mod tests {
         let expected = GenomeSize(10050);
 
         assert_eq!(actual, expected)
+    }
+
+    #[test]
+    fn genome_size_from_faidx_with_missing_length_field_errors_instead_of_panicking() {
+        use std::io::Write;
+
+        let mut file = tempfile::Builder::new().suffix(".fai").tempfile().unwrap();
+        // a faidx line with no length (2nd) field
+        file.write_all(b"chr1\n").unwrap();
+
+        let actual = GenomeSize::from_faidx(file.path());
+
+        assert!(matches!(actual, Err(CliError::FaidxError(_))));
     }
 
     #[test]

--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -72,6 +72,26 @@ impl Fastx {
     }
 }
 
+impl Fastx {
+    /// Opens the underlying (possibly compressed) file as a FASTA/Q record reader.
+    ///
+    /// Returns `Ok(None)` for a too-short/empty file, matching the pre-existing
+    /// "no records" handling shared by [`RecordSource::read_lengths`] and
+    /// [`RecordSource::count`].
+    fn open_reader(&self) -> Result<Option<Box<dyn needletail::parser::FastxReader>>, FastxError> {
+        let reader = match niffler::send::from_path(&self.path) {
+            Ok((rdr, _)) => rdr,
+            Err(niffler::error::Error::FileTooShort) => return Ok(None),
+            Err(source) => return Err(FastxError::CompressOutputError(source)),
+        };
+        match needletail::parse_fastx_reader(reader) {
+            Ok(rdr) => Ok(Some(rdr)),
+            Err(e) if e.kind == EmptyFile => Ok(None),
+            Err(source) => Err(FastxError::ReadError { source }),
+        }
+    }
+}
+
 impl RecordSource for Fastx {
     /// Returns a vector containing the lengths of all the reads in the file.
     ///
@@ -96,17 +116,9 @@ impl RecordSource for Fastx {
     fn read_lengths(&self) -> Result<Vec<u32>, FastxError> {
         let mut read_lengths: Vec<u32> = vec![];
 
-        let reader = match niffler::send::from_path(&self.path) {
-            Ok((rdr, _)) => rdr,
-            Err(source) => match source {
-                niffler::error::Error::FileTooShort => return Ok(read_lengths),
-                _ => return Err(FastxError::CompressOutputError(source)),
-            },
-        };
-        let mut reader = match needletail::parse_fastx_reader(reader) {
-            Ok(rdr) => rdr,
-            Err(e) if e.kind == EmptyFile => return Ok(read_lengths),
-            Err(source) => return Err(FastxError::ReadError { source }),
+        let mut reader = match self.open_reader()? {
+            Some(rdr) => rdr,
+            None => return Ok(read_lengths),
         };
 
         while let Some(record) = reader.next() {
@@ -116,6 +128,37 @@ impl RecordSource for Fastx {
             }
         }
         Ok(read_lengths)
+    }
+
+    /// Returns the number of records in the file, without materializing their lengths.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rasusa::fastx::Fastx;
+    /// use rasusa::source::RecordSource;
+    /// use std::io::Write;
+    /// let text = "@read1\nACGT\n+\n!!!!\n@read2\nG\n+\n!";
+    /// let mut file = tempfile::Builder::new().suffix(".fq").tempfile().unwrap();
+    /// file.write_all(text.as_bytes()).unwrap();
+    /// let fastx = Fastx::from_path(file.path());
+    /// assert_eq!(fastx.count().unwrap(), 2)
+    /// ```
+    fn count(&self) -> Result<usize, FastxError> {
+        let mut count: usize = 0;
+
+        let mut reader = match self.open_reader()? {
+            Some(rdr) => rdr,
+            None => return Ok(count),
+        };
+
+        while let Some(record) = reader.next() {
+            match record {
+                Ok(_) => count += 1,
+                Err(err) => return Err(FastxError::ParseError { source: err }),
+            }
+        }
+        Ok(count)
     }
 
     /// Writes reads, with indices contained within `reads_to_keep`, to the specified handle
@@ -148,7 +191,7 @@ impl RecordSource for Fastx {
         while let Some(record) = reader.next() {
             match record {
                 Err(source) => return Err(FastxError::ParseError { source }),
-                Ok(rec) if reads_to_keep[read_idx] => {
+                Ok(rec) if read_idx < reads_to_keep.len() && reads_to_keep[read_idx] => {
                     total_len += rec.num_bases();
                     if is_fasta {
                         write_to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod subsampler;
 
 pub use crate::cli::Cli;
 pub use crate::fastx::Fastx;
-pub use crate::subsampler::SubSampler;
+pub use crate::subsampler::{SubSampler, SubsampleMode};
 
 pub trait Runner {
     fn run(&mut self) -> Result<()>;

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -3,11 +3,11 @@ use crate::cli::{
     GenomeSize,
 };
 use crate::fastx::create_output_writer;
-use crate::source::determine_record_source;
-use crate::{Runner, SubSampler};
+use crate::source::{determine_record_source, RecordSource};
+use crate::{Runner, SubSampler, SubsampleMode};
 use anyhow::{Context, Result};
 use clap::Parser;
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 use niffler::compression;
 use std::io::{stdout, BufWriter};
 use std::path::{Path, PathBuf};
@@ -217,6 +217,37 @@ impl Runner for Reads {
                 .context("unable to create the first output file")?,
         };
 
+        let second_input_source = if is_paired {
+            Some(determine_record_source(&self.input[1]))
+        } else {
+            None
+        };
+
+        self.subsample(
+            input_source.as_ref(),
+            second_input_source.as_deref(),
+            &mut *output_handle,
+        )
+    }
+}
+
+impl Reads {
+    /// Runs the core subsampling orchestration against already-constructed sources and sinks.
+    ///
+    /// This is the in-process seam used by both [`Runner::run`] (which builds the first
+    /// source/sink from `self.input[0]`/`self.output`) and unit tests (which can inject a source
+    /// backed by a temp file and an in-memory `Vec<u8>` sink, without spawning the CLI as a
+    /// subprocess). The second (paired-mode) output is always file-backed - as it was before this
+    /// seam existed - so it's still constructed from `self.output[1]` here rather than injected.
+    fn subsample(
+        &self,
+        input_source: &dyn RecordSource,
+        second_input_source: Option<&dyn RecordSource>,
+        output_handle: &mut dyn std::io::Write,
+    ) -> Result<()> {
+        let is_paired = second_input_source.is_some();
+        let input_format = crate::alignment::infer_format_from_path(&self.input[0]);
+
         let target_total_bases: Option<u64> = match (self.genome_size, self.coverage, self.bases) {
             (_, _, Some(bases)) => Some(u64::from(bases)),
             (Some(gsize), Some(cov), _) => Some(gsize * cov),
@@ -227,107 +258,122 @@ impl Runner for Reads {
             info!("Target number of bases to subsample to is: {bases}",);
         }
 
-        info!("Gathering read lengths...");
-        let mut read_lengths = input_source
-            .read_lengths()
-            .context("unable to gather read lengths for the first input file")?;
-
-        if is_paired {
-            let second_input_source = determine_record_source(&self.input[1]);
-            let expected_num_reads = read_lengths.len();
-            info!("Gathering read lengths for second input file...");
-            let mate_lengths = second_input_source
+        let (mode, total_reads, read_lengths) = if let Some(ttb) = target_total_bases {
+            info!("Gathering read lengths...");
+            let mut lengths = input_source
                 .read_lengths()
-                .context("unable to gather read lengths for the second input file")?;
+                .context("unable to gather read lengths for the first input file")?;
 
-            if mate_lengths.len() != expected_num_reads {
-                error!("First input has {} reads, but the second has {} reads. Paired Illumina files are assumed to have the same number of reads. The results of this subsample may not be as expected now.", expected_num_reads, read_lengths.len());
-                std::process::exit(1);
-            } else {
-                info!(
-                    "Both input files have the same number of reads ({}) 👍",
-                    expected_num_reads
-                );
-            }
-            // add the paired read lengths to the existing lengths
-            for (i, len) in mate_lengths.iter().enumerate() {
-                read_lengths[i] += len;
-            }
-        }
-        info!("{} reads detected", read_lengths.len());
+            if let Some(second_source) = second_input_source {
+                let expected_num_reads = lengths.len();
+                info!("Gathering read lengths for second input file...");
+                let mate_lengths = second_source
+                    .read_lengths()
+                    .context("unable to gather read lengths for the second input file")?;
 
-        let total_input_bases: u64 = read_lengths.iter().map(|&x| x as u64).sum();
-
-        // calculate the depth of coverage if using coverage-based subsampling
-        if let Some(size) = self.genome_size {
-            let depth_of_covg = (total_input_bases as f64) / f64::from(size);
-            info!("Input coverage is {:.2}x", depth_of_covg);
-
-            if self.strict
-                && target_total_bases.is_some()
-                && Coverage(depth_of_covg as f32) < self.coverage.unwrap()
-            {
-                return Err(anyhow::anyhow!(
-                    "Requested coverage ({:.2}x) is not possible as the actual coverage is {:.2}x",
-                    self.coverage.unwrap().0,
-                    depth_of_covg
-                ));
-            }
-        }
-
-        if let Some(req_bases) = self.bases {
-            let req_bases = u64::from(req_bases);
-            if self.strict && req_bases > total_input_bases {
-                return Err(anyhow::anyhow!(
-                    "Requested number of bases ({}) is more than the input ({})",
-                    req_bases,
-                    total_input_bases
-                ));
-            }
-        }
-
-        let num_reads = match (self.num, self.frac) {
-            (Some(n), None) => Some(u64::from(n)),
-            (None, Some(f)) => {
-                let n = ((f as f64) * (read_lengths.len() as f64)).round() as u64;
-                if n == 0 {
-                    if !self.strict {
-                        warn!(
-                            "Requested fraction of reads ({} * {}) was rounded to 0",
-                            f,
-                            read_lengths.len()
-                        );
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "Requested fraction of reads ({} * {}) was rounded to 0",
-                            f,
-                            read_lengths.len()
-                        ));
-                    }
+                check_paired_counts(expected_num_reads, mate_lengths.len())?;
+                // add the paired read lengths to the existing lengths
+                for (i, len) in mate_lengths.iter().enumerate() {
+                    lengths[i] += len;
                 }
-                Some(n)
             }
-            _ => None,
-        };
+            info!("{} reads detected", lengths.len());
 
-        if let Some(n) = num_reads {
-            if self.strict && n as usize > read_lengths.len() {
+            let total_input_bases: u64 = lengths.iter().map(|&x| x as u64).sum();
+
+            // calculate the depth of coverage if using coverage-based subsampling
+            if let Some(size) = self.genome_size {
+                let depth_of_covg = (total_input_bases as f64) / f64::from(size);
+                info!("Input coverage is {:.2}x", depth_of_covg);
+
+                if self.strict && Coverage(depth_of_covg as f32) < self.coverage.unwrap() {
+                    return Err(anyhow::anyhow!(
+                        "Requested coverage ({:.2}x) is not possible as the actual coverage is {:.2}x",
+                        self.coverage.unwrap().0,
+                        depth_of_covg
+                    ));
+                }
+            }
+
+            if let Some(req_bases) = self.bases {
+                let req_bases = u64::from(req_bases);
+                if self.strict && req_bases > total_input_bases {
+                    return Err(anyhow::anyhow!(
+                        "Requested number of bases ({}) is more than the input ({})",
+                        req_bases,
+                        total_input_bases
+                    ));
+                }
+            }
+
+            let total_reads = lengths.len();
+            (SubsampleMode::ByBases(ttb), total_reads, lengths)
+        } else {
+            // in this mode, selection only depends on the read *count* - avoid gathering the
+            // (unused) per-read lengths vector.
+            info!("Counting reads...");
+            let first_count = input_source
+                .count()
+                .context("unable to count reads in the first input file")?;
+
+            let total_reads = if let Some(second_source) = second_input_source {
+                info!("Counting reads in second input file...");
+                let second_count = second_source
+                    .count()
+                    .context("unable to count reads in the second input file")?;
+
+                check_paired_counts(first_count, second_count)?;
+                first_count
+            } else {
+                first_count
+            };
+            info!("{} reads detected", total_reads);
+
+            let n = match (self.num, self.frac) {
+                (Some(n), None) => u64::from(n),
+                (None, Some(f)) => {
+                    let n = ((f as f64) * (total_reads as f64)).round() as u64;
+                    if n == 0 {
+                        if !self.strict {
+                            warn!(
+                                "Requested fraction of reads ({} * {}) was rounded to 0",
+                                f, total_reads
+                            );
+                        } else {
+                            return Err(anyhow::anyhow!(
+                                "Requested fraction of reads ({} * {}) was rounded to 0",
+                                f,
+                                total_reads
+                            ));
+                        }
+                    }
+                    n
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "Either --num or --frac must be given when not subsampling by --bases/--coverage"
+                    ));
+                }
+            };
+
+            if self.strict && n as usize > total_reads {
                 return Err(anyhow::anyhow!(
                     "Requested number of reads ({}) is more than the input ({})",
                     n,
-                    read_lengths.len()
+                    total_reads
                 ));
             }
             info!("Target number of reads to subsample to is: {}", n);
-        }
 
-        let subsampler = SubSampler {
-            target_total_bases,
-            seed: self.seed,
-            num_reads,
+            (SubsampleMode::ByReads(n), total_reads, Vec::new())
         };
 
-        let (reads_to_keep, nb_reads_to_keep) = subsampler.indices(&read_lengths);
+        let subsampler = SubSampler {
+            mode,
+            seed: self.seed,
+        };
+
+        let (reads_to_keep, nb_reads_to_keep) = subsampler.indices(total_reads, &read_lengths);
         if is_paired {
             info!("Keeping {} reads from each input", nb_reads_to_keep);
         } else {
@@ -373,14 +419,13 @@ impl Runner for Reads {
         let mut total_kept_bases = input_source.filter_reads_into(
             &reads_to_keep,
             nb_reads_to_keep,
-            &mut output_handle,
+            output_handle,
             output_format_1,
             is_fasta_1,
         )? as u64;
 
         // repeat the same process for the second input (if illumina)
-        if is_paired {
-            let second_input_source = determine_record_source(&self.input[1]);
+        if let Some(second_input_source) = second_input_source {
             let second_input_format = crate::alignment::infer_format_from_path(&self.input[1]);
 
             let mut second_output_handle =
@@ -452,6 +497,25 @@ impl Runner for Reads {
     }
 }
 
+/// Checks that a paired input's two files report the same number of reads, logging a success
+/// message on match. Both "by bases" (per-file `read_lengths().len()`) and "by reads"
+/// (per-file `count()`) branches of [`Reads::subsample`] hit the same mismatch condition and
+/// want the same error/log wording.
+fn check_paired_counts(first_count: usize, second_count: usize) -> Result<()> {
+    if second_count != first_count {
+        return Err(anyhow::anyhow!(
+            "First input has {} reads, but the second has {} reads. Paired Illumina files are assumed to have the same number of reads.",
+            first_count,
+            second_count
+        ));
+    }
+    info!(
+        "Both input files have the same number of reads ({}) 👍",
+        first_count
+    );
+    Ok(())
+}
+
 fn is_fasta_path(path: &Path) -> bool {
     let mut p = path.to_path_buf();
     if let Some(ext) = p.extension().map(|e| e.to_string_lossy().to_lowercase()) {
@@ -467,9 +531,173 @@ fn is_fasta_path(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::fastx::Fastx;
     use assert_cmd::Command;
+    use std::io::Write as _;
+    use std::str::FromStr;
+    use tempfile::NamedTempFile;
 
     const SUB: &str = "reads";
+
+    /// Builds a temp FASTQ file with `n` reads, each `len` bases long, for use with the
+    /// in-process `subsample` seam (mirrors the pattern `alignment.rs` uses for its own
+    /// in-process tests, but for the reads path).
+    fn write_fastq(n: usize, len: usize) -> NamedTempFile {
+        let mut file = NamedTempFile::with_suffix(".fq").unwrap();
+        let seq = "A".repeat(len);
+        let qual = "I".repeat(len);
+        for i in 0..n {
+            writeln!(file, "@read{i}\n{seq}\n+\n{qual}").unwrap();
+        }
+        file.flush().unwrap();
+        file
+    }
+
+    fn default_reads(input: Vec<PathBuf>) -> Reads {
+        Reads {
+            input,
+            output: vec![],
+            genome_size: None,
+            coverage: None,
+            bases: None,
+            num: None,
+            frac: None,
+            strict: false,
+            seed: Some(1),
+            verbose: false,
+            compress_type: None,
+            output_format: None,
+            compress_level: None,
+        }
+    }
+
+    #[test]
+    fn frac_rounds_to_zero_without_strict_warns_and_keeps_nothing() {
+        let input = write_fastq(2, 10);
+        let source = Fastx::from_path(input.path());
+        let mut reads = default_reads(vec![input.path().to_path_buf()]);
+        reads.frac = Some(0.01); // 0.01 * 2 rounds to 0
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source, None, &mut output);
+
+        assert!(result.is_ok());
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn frac_rounds_to_zero_with_strict_returns_err() {
+        let input = write_fastq(2, 10);
+        let source = Fastx::from_path(input.path());
+        let mut reads = default_reads(vec![input.path().to_path_buf()]);
+        reads.frac = Some(0.01);
+        reads.strict = true;
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source, None, &mut output);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn num_more_than_available_with_strict_returns_err() {
+        let input = write_fastq(2, 10);
+        let source = Fastx::from_path(input.path());
+        let mut reads = default_reads(vec![input.path().to_path_buf()]);
+        reads.num = Some(GenomeSize::from_str("10").unwrap());
+        reads.strict = true;
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source, None, &mut output);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn num_more_than_available_without_strict_keeps_all() {
+        let input = write_fastq(2, 10);
+        let source = Fastx::from_path(input.path());
+        let mut reads = default_reads(vec![input.path().to_path_buf()]);
+        reads.num = Some(GenomeSize::from_str("10").unwrap());
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source, None, &mut output);
+
+        assert!(result.is_ok());
+        assert_eq!(output.iter().filter(|&&b| b == b'@').count(), 2);
+    }
+
+    #[test]
+    fn insufficient_coverage_without_strict_warns_instead_of_erroring() {
+        // 2 reads * 10 bases = 20 bases total, requesting 5000x coverage of a 1000bp genome
+        // (5,000,000 bases) is unattainable - this should warn, not error, when not strict.
+        let input = write_fastq(2, 10);
+        let source = Fastx::from_path(input.path());
+        let mut reads = default_reads(vec![input.path().to_path_buf()]);
+        reads.genome_size = Some(GenomeSize::from_str("1000").unwrap());
+        reads.coverage = Some(Coverage(5000.0));
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source, None, &mut output);
+
+        // all reads get kept (can never reach the target), but this is not an error
+        assert!(result.is_ok());
+        assert_eq!(output.iter().filter(|&&b| b == b'@').count(), 2);
+    }
+
+    #[test]
+    fn insufficient_coverage_with_strict_returns_err() {
+        let input = write_fastq(2, 10);
+        let source = Fastx::from_path(input.path());
+        let mut reads = default_reads(vec![input.path().to_path_buf()]);
+        reads.genome_size = Some(GenomeSize::from_str("1000").unwrap());
+        reads.coverage = Some(Coverage(5000.0));
+        reads.strict = true;
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source, None, &mut output);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn paired_read_count_mismatch_returns_err_instead_of_exiting() {
+        let input1 = write_fastq(3, 10);
+        let input2 = write_fastq(2, 10);
+        let source1 = Fastx::from_path(input1.path());
+        let source2 = Fastx::from_path(input2.path());
+        let mut reads = default_reads(vec![
+            input1.path().to_path_buf(),
+            input2.path().to_path_buf(),
+        ]);
+        reads.num = Some(GenomeSize::from_str("1").unwrap());
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source1, Some(&source2), &mut output);
+
+        let err = result.expect_err("mismatched paired read counts should be an error");
+        assert!(err.to_string().contains("First input has"));
+    }
+
+    #[test]
+    fn paired_read_count_mismatch_by_bases_returns_err_instead_of_exiting() {
+        let input1 = write_fastq(3, 10);
+        let input2 = write_fastq(2, 10);
+        let source1 = Fastx::from_path(input1.path());
+        let source2 = Fastx::from_path(input2.path());
+        let mut reads = default_reads(vec![
+            input1.path().to_path_buf(),
+            input2.path().to_path_buf(),
+        ]);
+        reads.bases = Some(GenomeSize::from_str("10").unwrap());
+
+        let mut output = Vec::new();
+        let result = reads.subsample(&source1, Some(&source2), &mut output);
+
+        let err = result.expect_err("mismatched paired read counts should be an error");
+        assert!(err.to_string().contains("First input has"));
+    }
 
     #[test]
     fn no_args_given_raises_error() {

--- a/src/source.rs
+++ b/src/source.rs
@@ -10,6 +10,9 @@ use std::path::{Path, PathBuf};
 
 pub trait RecordSource {
     fn read_lengths(&self) -> Result<Vec<u32>, FastxError>;
+    /// Returns the number of reads (or read templates, for paired alignment data) in the source,
+    /// without materializing their individual lengths.
+    fn count(&self) -> Result<usize, FastxError>;
     fn filter_reads_into(
         &self,
         reads_to_keep: &[bool],
@@ -92,6 +95,44 @@ impl RecordSource for AlignmentSource {
         }
 
         Ok(read_lengths)
+    }
+
+    fn count(&self) -> Result<usize, FastxError> {
+        let mut reader = noodles_util::alignment::io::reader::Builder::default()
+            .build_from_path(&self.path)
+            .map_err(|source| FastxError::AlignmentReadError { source })?;
+
+        let header = reader
+            .read_header()
+            .map_err(|source| FastxError::AlignmentReadError { source })?;
+
+        let mut count: usize = 0;
+        let mut qname_seen: HashSet<Vec<u8>> = HashSet::new();
+
+        for result in reader.records(&header) {
+            let record = result.map_err(|source| FastxError::AlignmentReadError { source })?;
+            let flags = record
+                .flags()
+                .unwrap_or(noodles::sam::alignment::record::Flags::empty());
+
+            if !flags.is_unmapped() {
+                return Err(FastxError::MappedReadDetected);
+            }
+
+            if flags.is_segmented() {
+                let name = record
+                    .name()
+                    .map(|n| (n.as_ref() as &[u8]).to_vec())
+                    .unwrap_or_default();
+                if qname_seen.insert(name) {
+                    count += 1;
+                }
+            } else {
+                count += 1;
+            }
+        }
+
+        Ok(count)
     }
 
     fn filter_reads_into(
@@ -364,6 +405,27 @@ mod tests {
         assert_eq!(actual.len(), 2);
         assert_eq!(actual[0], 20);
         assert_eq!(actual[1], 20);
+    }
+
+    #[test]
+    fn test_alignment_source_count() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("test.sam");
+        create_test_sam(&path);
+
+        let source = AlignmentSource::new(&path);
+        assert_eq!(source.count().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_alignment_source_count_paired_dedups_by_template() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("test_paired.sam");
+        create_test_paired_sam(&path);
+
+        let source = AlignmentSource::new(&path);
+        // 4 records but 2 templates (read pairs)
+        assert_eq!(source.count().unwrap(), 2);
     }
 
     #[test]

--- a/src/subsampler.rs
+++ b/src/subsampler.rs
@@ -2,48 +2,35 @@ use log::info;
 use rand::prelude::*;
 use rand::random;
 
+/// The target used to decide how many reads to keep.
+///
+/// Modelling this as an enum (rather than two `Option<u64>` fields) makes the "both
+/// set"/"neither set" states unrepresentable - callers must pick exactly one mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubsampleMode {
+    /// Keep reads (in shuffled order) until this many total bases have been kept.
+    ByBases(u64),
+    /// Keep exactly this many reads (or all of them, if fewer are available).
+    ByReads(u64),
+}
+
 /// A `Struct` for dealing with the randomised part of sub-sampling.
 pub struct SubSampler {
-    /// Number of bases to sub-sample down to.    
-    pub target_total_bases: Option<u64>,
+    /// The target to sub-sample down to.
+    pub mode: SubsampleMode,
     /// Random seed to use for sub-sampling. If `None` is used, then the random number generator
     /// will be seeded by the operating system.
     pub seed: Option<u64>,
-    /// Number of reads to subsample down to
-    pub num_reads: Option<u64>,
 }
 
 impl SubSampler {
-    /// Returns a vector of indices for elements in `v`, but shuffled.
+    /// Returns a vector of `0..n`, but shuffled.
     ///
     /// # Note
     ///
     /// If the file has more than 4,294,967,296 reads, this function's behaviour is undefined.
-    ///
-    /// # Example
-    ///
-    // TODO(S9): stale doctest - `shuffled_indices` is private (can't be called from an
-    // external doctest) and the struct literal is missing `num_reads`. Fix or rewrite
-    // as a unit test in the S9 doctest/test cleanup pass.
-    /// ```rust,ignore
-    /// let v: Vec<u64> = vec![55, 1];
-    /// let sampler = SubSampler {
-    ///     target_total_bases: 100,
-    ///     seed: None,
-    /// };
-    /// let mut num_times_shuffled = 0;
-    /// let iterations = 500;
-    /// for _ in 0..iterations {
-    ///     let idxs = sampler.shuffled_indices(&v);
-    ///     if idxs == vec![1, 0] {
-    ///         num_times_shuffled += 1;
-    ///     }
-    /// }
-    /// // chances of shuffling the same way 100 times in a row is 3.054936363499605e-151
-    /// assert!(num_times_shuffled > 0 && num_times_shuffled < iterations)
-    /// ```
-    fn shuffled_indices<T>(&self, v: &[T]) -> Vec<u32> {
-        let mut indices: Vec<u32> = (0..v.len() as u32).collect();
+    fn shuffled_indices(&self, n: usize) -> Vec<u32> {
+        let mut indices: Vec<u32> = (0..n as u32).collect();
 
         let mut rng = match self.seed {
             Some(s) => rand_pcg::Pcg64::seed_from_u64(s),
@@ -58,46 +45,35 @@ impl SubSampler {
         indices
     }
 
-    /// Sub-samples `lengths` to the desired `target_total_bases` specified in the `SubSampler` and
-    /// returns the indices for the reads that were selected.
+    /// Sub-samples `total_reads` reads down to the target specified in `self.mode` and returns,
+    /// for each read index, whether it was selected.
     ///
-    /// # Example
+    /// `lengths` is only consulted in [`SubsampleMode::ByBases`] mode - callers using
+    /// [`SubsampleMode::ByReads`] may pass an empty slice, since selection there only depends on
+    /// `total_reads`.
     ///
-    // TODO(S9): stale doctest - struct literal is missing `num_reads`, and `indices`
-    // returns `(Vec<bool>, usize)`, not a directly-indexable collection. Fix or rewrite
-    // as a unit test in the S9 doctest/test cleanup pass.
-    /// ```rust,ignore
-    /// let v: Vec<u32> = vec![50, 50, 50];
-    /// let sampler = SubSampler {
-    ///     target_total_bases: 100,
-    ///     seed: Some(1),
-    /// };
-    /// let actual = sampler.indices(&v);
-    ///
-    /// assert_eq!(actual.len(), 3);
-    /// assert!(actual[1]);
-    /// assert!(actual[2]);
-    /// assert!(actual[3]);
-    /// ```
-    pub fn indices(&self, lengths: &[u32]) -> (Vec<bool>, usize) {
-        let mut indices = self.shuffled_indices(lengths).into_iter();
-        let mut to_keep: Vec<bool> = vec![false; lengths.len()];
-        let mut total_bases_kept: u64 = 0;
-
+    /// # Panics
+    /// Panics (via an out-of-bounds index) if `mode` is `ByBases` and `lengths.len() !=
+    /// total_reads`.
+    pub fn indices(&self, total_reads: usize, lengths: &[u32]) -> (Vec<bool>, usize) {
+        let mut indices = self.shuffled_indices(total_reads).into_iter();
+        let mut to_keep: Vec<bool> = vec![false; total_reads];
         let mut nb_reads_to_keep = 0;
-        match (self.target_total_bases, self.num_reads) {
-            (Some(ttb), None) => {
-                while total_bases_kept < ttb {
+
+        match self.mode {
+            SubsampleMode::ByBases(target_total_bases) => {
+                let mut total_bases_kept: u64 = 0;
+                while total_bases_kept < target_total_bases {
                     let idx = match indices.next() {
                         Some(i) => i as usize,
                         None => break,
                     };
                     to_keep[idx] = true;
-                    total_bases_kept += u64::from(lengths[idx.to_owned()]);
+                    total_bases_kept += u64::from(lengths[idx]);
                     nb_reads_to_keep += 1;
                 }
             }
-            (None, Some(n_reads)) => {
+            SubsampleMode::ByReads(n_reads) => {
                 nb_reads_to_keep = (n_reads as usize).min(indices.len());
                 if nb_reads_to_keep == indices.len() {
                     to_keep.fill(true);
@@ -107,7 +83,6 @@ impl SubSampler {
                     }
                 }
             }
-            _ => panic!("Subsampler::inices got an unexpected combination. Please report this bug"),
         }
 
         (to_keep, nb_reads_to_keep)
@@ -119,47 +94,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn shuffled_indices_for_empty_vector_returns_empty() {
-        let v: Vec<u64> = Vec::new();
+    fn shuffled_indices_for_zero_returns_empty() {
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
-        let actual = sampler.shuffled_indices(&v);
+        let actual = sampler.shuffled_indices(0);
 
         assert!(actual.is_empty())
     }
 
     #[test]
-    fn shuffled_indices_for_vector_len_one_returns_zero() {
-        let v: Vec<u64> = vec![55];
+    fn shuffled_indices_for_one_returns_zero() {
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
-        let actual = sampler.shuffled_indices(&v);
+        let actual = sampler.shuffled_indices(1);
         let expected: Vec<u32> = vec![0];
 
         assert_eq!(actual, expected)
     }
 
     #[test]
-    fn shuffled_indices_for_vector_len_two_does_shuffle() {
-        let v: Vec<u64> = vec![55, 1];
+    fn shuffled_indices_for_two_does_shuffle() {
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
         let mut num_times_shuffled = 0;
         let iterations = 500;
         for _ in 0..iterations {
-            let idxs = sampler.shuffled_indices(&v);
+            let idxs = sampler.shuffled_indices(2);
             if idxs == vec![1, 0] {
                 num_times_shuffled += 1;
             }
@@ -171,20 +140,17 @@ mod tests {
 
     #[test]
     fn shuffled_indices_with_seed_produces_same_ordering() {
-        let v: Vec<u64> = vec![55, 1, 8];
         let sampler1 = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: Some(1),
-            num_reads: None,
         };
 
         let sampler2 = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: Some(1),
-            num_reads: None,
         };
-        let idxs1 = sampler1.shuffled_indices(&v);
-        let idxs2 = sampler2.shuffled_indices(&v);
+        let idxs1 = sampler1.shuffled_indices(3);
+        let idxs2 = sampler2.shuffled_indices(3);
 
         for i in 0..idxs1.len() {
             assert_eq!(idxs1[i], idxs2[i])
@@ -193,42 +159,36 @@ mod tests {
 
     #[test]
     fn subsample_empty_lengths_returns_empty() {
-        let v: Vec<u32> = Vec::new();
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
-        let (_, nb_select) = sampler.indices(&v);
+        let (_, nb_select) = sampler.indices(0, &[]);
 
         assert_eq!(nb_select, 0)
     }
 
     #[test]
     fn subsample_one_length_target_zero_returns_empty() {
-        let v: Vec<u32> = Vec::new();
         let sampler = SubSampler {
-            target_total_bases: Some(0),
+            mode: SubsampleMode::ByBases(0),
             seed: None,
-            num_reads: None,
         };
 
-        let (_, nb_select) = sampler.indices(&v);
+        let (_, nb_select) = sampler.indices(0, &[]);
 
         assert_eq!(nb_select, 0);
     }
 
     #[test]
     fn subsample_one_read_target_zero_returns_empty() {
-        let v: Vec<u32> = Vec::new();
         let sampler = SubSampler {
-            target_total_bases: None,
+            mode: SubsampleMode::ByReads(5),
             seed: None,
-            num_reads: Some(5),
         };
 
-        let (_, nb_select) = sampler.indices(&v);
+        let (_, nb_select) = sampler.indices(0, &[]);
 
         assert_eq!(nb_select, 0);
     }
@@ -237,12 +197,11 @@ mod tests {
     fn subsample_one_length_less_than_target_returns_zero() {
         let v: Vec<u32> = vec![5];
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
-        let (actual, nb_select) = sampler.indices(&v);
+        let (actual, nb_select) = sampler.indices(v.len(), &v);
 
         assert_eq!(nb_select, 1);
         assert!(actual[0])
@@ -250,14 +209,12 @@ mod tests {
 
     #[test]
     fn subsample_more_reads_than_available_takes_all() {
-        let v: Vec<u32> = vec![5];
         let sampler = SubSampler {
-            target_total_bases: None,
+            mode: SubsampleMode::ByReads(10),
             seed: None,
-            num_reads: Some(10),
         };
 
-        let (actual, nb_select) = sampler.indices(&v);
+        let (actual, nb_select) = sampler.indices(1, &[]);
 
         assert_eq!(nb_select, 1);
         assert!(actual[0])
@@ -265,14 +222,12 @@ mod tests {
 
     #[test]
     fn subsample_num_reads_and_available_equal_takes_all() {
-        let v: Vec<u32> = vec![5, 5, 66];
         let sampler = SubSampler {
-            target_total_bases: None,
+            mode: SubsampleMode::ByReads(3),
             seed: None,
-            num_reads: Some(3),
         };
 
-        let (actual, nb_select) = sampler.indices(&v);
+        let (actual, nb_select) = sampler.indices(3, &[]);
 
         assert_eq!(nb_select, 3);
         assert!(actual.iter().all(|e| *e))
@@ -280,14 +235,12 @@ mod tests {
 
     #[test]
     fn subsample_num_reads_less_than_available_takes_subset() {
-        let v: Vec<u32> = vec![5, 5, 66];
         let sampler = SubSampler {
-            target_total_bases: None,
+            mode: SubsampleMode::ByReads(2),
             seed: None,
-            num_reads: Some(2),
         };
 
-        let (actual, nb_select) = sampler.indices(&v);
+        let (actual, nb_select) = sampler.indices(3, &[]);
 
         assert_eq!(nb_select, 2);
 
@@ -299,12 +252,11 @@ mod tests {
     fn subsample_one_length_greater_than_target_returns_zero() {
         let v: Vec<u32> = vec![500];
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
-        let (actual, nb_select) = sampler.indices(&v);
+        let (actual, nb_select) = sampler.indices(v.len(), &v);
 
         assert_eq!(nb_select, 1);
         assert!(actual[0])
@@ -314,12 +266,11 @@ mod tests {
     fn subsample_three_lengths_sum_greater_than_target_returns_two() {
         let v: Vec<u32> = vec![50, 50, 50];
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: Some(1),
-            num_reads: None,
         };
 
-        let (actual, nb_select) = sampler.indices(&v);
+        let (actual, nb_select) = sampler.indices(v.len(), &v);
 
         assert_eq!(nb_select, 2);
         assert!(!actual[0]);
@@ -331,12 +282,11 @@ mod tests {
     fn subsample_three_lengths_sum_less_than_target_returns_three() {
         let v: Vec<u32> = vec![5, 5, 5];
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
-        let (actual, _) = sampler.indices(&v);
+        let (actual, _) = sampler.indices(v.len(), &v);
         let expected = vec![true; 3];
 
         assert_eq!(actual, expected);
@@ -346,12 +296,11 @@ mod tests {
     fn subsample_three_lengths_sum_equal_target_returns_three() {
         let v: Vec<u32> = vec![25, 25, 50];
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: None,
-            num_reads: None,
         };
 
-        let (actual, _) = sampler.indices(&v);
+        let (actual, _) = sampler.indices(v.len(), &v);
         let expected = vec![true; 3];
 
         assert_eq!(actual, expected);
@@ -361,12 +310,11 @@ mod tests {
     fn subsample_three_lengths_all_greater_than_target_returns_two() {
         let v: Vec<u32> = vec![500, 500, 500];
         let sampler = SubSampler {
-            target_total_bases: Some(100),
+            mode: SubsampleMode::ByBases(100),
             seed: Some(1),
-            num_reads: None,
         };
 
-        let (actual, nb_select) = sampler.indices(&v);
+        let (actual, nb_select) = sampler.indices(v.len(), &v);
         println!("{actual:?}");
 
         assert_eq!(nb_select, 1);


### PR DESCRIPTION
## Summary
- Extracts `Reads::subsample`, an in-process seam taking a `RecordSource` + a `dyn Write`, out of `Runner::run` for `Reads` - makes the core orchestration logic unit-testable without spawning the CLI as a subprocess.
- Replaces a `process::exit(1)` on paired read-count mismatch with a returned `Err`.
- Models the subsample target as `SubsampleMode { ByBases(u64), ByReads(u64) }`, removing the unreachable panic on illegal `(None, None)`/`(Some, Some)` mode combinations. Selection algorithm (full shuffle) is unchanged.
- Bounds-checks the faidx parse into `CliError::FaidxError` instead of panicking on malformed lines (`fields[1]` -> `fields.get(1)`).
- Aligns `Fastx::filter_reads_into`'s indexing with `AlignmentSource`'s existing guarded-bounds style.
- Adds `RecordSource::count()` (implemented for both `Fastx` and `AlignmentSource`) and uses it on the `--num`/`--frac` path so it no longer materializes an unused per-read lengths vector - a prerequisite for the O(k) selection algorithm landing in S10.
- Adds 9 new in-process unit tests covering round-to-zero (strict vs warn), num-more-than-available (strict vs warn), insufficient-coverage warning (strict vs warn), and paired count mismatch (both by-bases and by-reads modes), plus unit tests for the new `count()` methods and the faidx bounds-check.

Closes #174

## Test plan
- [x] `cargo build` / `cargo build --release` / `cargo bench --no-run`
- [x] `cargo fmt` / `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` (158 lib tests, 27 integration tests, 2 reproducibility tests, 5 doctests) all pass
- [x] Manual smoke test: `--num`, `--coverage`, and paired-mismatch scenarios on the release binary, confirming the new `count()` fast path is used for `--num`/`--frac` and the paired mismatch now surfaces as a normal `Error: ...` message (exit code 1) instead of a silent `process::exit`
- [x] Two-axis code review (Standards + Spec) run against the diff; addressed the two actionable findings (deduped paired-count-mismatch check into a shared helper, added a unit test for `AlignmentSource::count()`)