### PR TITLE
perf(alignment): replace ScoredRead with lightweight MappedRead domain type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "rand",
  "rand_pcg",
  "regex",
+ "rustc-hash",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -1255,6 +1256,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ env_logger = "0.11.9"
 noodles-util = { version = "0.78.0", features = ["alignment"] }
 noodles = { version = "0.109.0", features = ["bam", "cram", "core", "sam"] }
 noodles-bgzf = { version = "0.46.0", features = ["libdeflate"] }
+rustc-hash = "2.1"
 
 [dev-dependencies]
 assert_cmd = "2.2.0"

--- a/src/alignment/fetch.rs
+++ b/src/alignment/fetch.rs
@@ -1,18 +1,19 @@
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::BinaryHeap;
 
 use anyhow::{anyhow, Context, Result};
 use log::{info, warn};
 use rand::prelude::*;
 
 use noodles::core::{Position, Region};
-use noodles::sam::alignment::RecordBuf;
+use noodles::sam::alignment::Record;
 use noodles::sam::Header;
 use noodles_util::alignment::io::indexed_reader;
 
 use super::args::Alignment;
 use super::io::AlignmentWriter;
-use super::util::{extract_name, shuffle_records_by_position};
+use super::util::{alignment_start, extract_name, shuffle_grouped_by_position};
+use super::NameSet;
 
 impl Alignment {
     pub(super) fn run_fetch(&self) -> Result<()> {
@@ -29,7 +30,8 @@ impl Alignment {
         let is_paired = self.check_pair()?;
 
         let target_depth = self.get_target_depth(is_paired); // no memory allocation, do not need to convert into usize
-        let mut survivor_names: HashSet<Vec<u8>> = HashSet::new();
+        let mut survivor_names: NameSet =
+            NameSet::with_capacity_and_hasher(target_depth as usize, Default::default());
 
         if is_paired {
             info!("Detected Paired-End data");
@@ -58,7 +60,7 @@ impl Alignment {
         &self,
         target_depth: u32,
         paired_mode: bool,
-        survivor_names: &mut HashSet<Vec<u8>>,
+        survivor_names: &mut NameSet,
         header: &Header,
         writer: &mut AlignmentWriter,
         rng: &mut rand_pcg::Pcg64,
@@ -69,8 +71,11 @@ impl Alignment {
 
         let _ = reader.read_header()?;
 
-        // to hold batch of reads inside batch size query
-        let mut batch_cache: Vec<RecordBuf> = Vec::new();
+        // to hold batch of reads inside batch size query. Kept as the boxed record the reader
+        // already owns rather than eagerly parsed into a `RecordBuf` -- most cached reads are
+        // never selected, so paying for a full parse of every field of every read in the batch
+        // would be wasted work.
+        let mut batch_cache: Vec<Box<dyn Record>> = Vec::new();
 
         // how big of a chunk to grab at once
         let batch_size = self.batch_size as usize;
@@ -111,7 +116,7 @@ impl Alignment {
             let start_pos = next_pos;
 
             let mut n_reads_needed = target_depth;
-            let mut current_reads = HashSet::new();
+            let mut current_reads: NameSet = NameSet::default();
             let mut heap: BinaryHeap<Reverse<(usize, Vec<u8>)>> = BinaryHeap::new();
             let mut regions_below_coverage = false;
 
@@ -143,12 +148,12 @@ impl Alignment {
                     // query reads that intersect the region
                     let query = reader.query(header, &region)?;
 
-                    // put them in the cache
+                    // put them in the cache. The reader already hands back owned records, so no
+                    // conversion is needed here -- only the ones actually selected below get
+                    // written out.
                     for result in query {
                         let record = result?;
-                        // convert to owned Record, because we want shuffle these reads
-                        let recordbuf = RecordBuf::try_from_alignment_record(header, &record)?;
-                        batch_cache.push(recordbuf);
+                        batch_cache.push(record);
                     }
                 }
 
@@ -156,19 +161,21 @@ impl Alignment {
                 // similar as `reader.query(next_pos)`
 
                 // reads that overlaps at a certain position
-                let mut candidates: Vec<&RecordBuf> = Vec::new();
-                // ignore recordbuf that start after next_pos, https://doc.rust-lang.org/std/primitive.slice.html#method.partition_point
+                let mut candidates: Vec<&Box<dyn Record>> = Vec::new();
+                // ignore records that start after next_pos, https://doc.rust-lang.org/std/primitive.slice.html#method.partition_point
                 // i assume the input is sorted, because it requires the index
                 let partition_idx = batch_cache.partition_point(|r| {
-                    usize::from(r.alignment_start().unwrap_or(Position::MIN)) <= next_pos
+                    let start = alignment_start(r).unwrap_or(Position::MIN);
+                    usize::from(start) <= next_pos
                 });
 
                 for record in &batch_cache[..partition_idx] {
-                    if paired_mode && record.flags().is_last_segment() {
+                    if paired_mode && record.flags()?.is_last_segment() {
                         continue;
                     }
 
-                    let end = usize::from(record.alignment_end().unwrap_or(Position::MIN));
+                    let end =
+                        usize::from(record.alignment_end().transpose()?.unwrap_or(Position::MIN));
 
                     // just check if next_pos "inside" the reads
                     if end >= next_pos {
@@ -179,7 +186,9 @@ impl Alignment {
                 if next_pos == start_pos {
                     candidates.shuffle(rng);
                 } else {
-                    shuffle_records_by_position(&mut candidates, rng);
+                    // the batch is already sorted by position (it came straight from an indexed
+                    // query), so we only need to group-shuffle, not re-sort it first
+                    shuffle_grouped_by_position(&mut candidates, rng);
                 }
 
                 let mut num_output = 0;
@@ -197,7 +206,11 @@ impl Alignment {
                         continue;
                     }
 
-                    let end = record.alignment_end().map(usize::from).unwrap_or(next_pos);
+                    let end = record
+                        .alignment_end()
+                        .transpose()?
+                        .map(usize::from)
+                        .unwrap_or(next_pos);
 
                     current_reads.insert(qname.clone());
                     heap.push(Reverse((end, qname.clone())));

--- a/src/alignment/mod.rs
+++ b/src/alignment/mod.rs
@@ -16,10 +16,15 @@ use anyhow::{Context, Result};
 use log::info;
 use noodles::sam::Header;
 use noodles_util::alignment;
+use rustc_hash::FxBuildHasher;
 
 use crate::Runner;
 use io::AlignmentWriter;
 use util::extract_name;
+
+/// Set of read (QNAME) bytes, keyed with a fast non-cryptographic hasher since these are
+/// populated/queried heavily in paired-end mate recovery and offer no adversarial-input risk.
+pub(super) type NameSet = HashSet<Vec<u8>, FxBuildHasher>;
 
 impl Runner for Alignment {
     fn run(&mut self) -> Result<()> {
@@ -63,7 +68,7 @@ impl Alignment {
     // a helper function to scan the file linearly to find mates, only relevent on paired end illumina data
     fn recover_mates(
         &self,
-        survivor_names: &mut HashSet<Vec<u8>>,
+        survivor_names: &mut NameSet,
         header: &Header,
         writer: &mut AlignmentWriter,
     ) -> Result<()> {

--- a/src/alignment/model.rs
+++ b/src/alignment/model.rs
@@ -1,35 +1,53 @@
-use noodles::sam::alignment::RecordBuf;
+use noodles::sam::alignment::Record;
 
-// we implementes traits manually to avoid comparing the full record
+use super::util::extract_name;
+
+// we implement traits manually to avoid comparing the full record
 // primary comparison is based using the random priority 'key'
 // if there is tie (two read have the same key), then we use 'qname' to ensure the deterministic sorting still
-#[derive(Debug)]
-pub(super) struct ScoredRead {
+//
+// The record is kept as a boxed trait object (as returned by the noodles reader) rather than an
+// eagerly-parsed `RecordBuf`, so reads that never survive don't pay for a full field-by-field parse.
+// `key`/`start`/`end`/`name` are extracted once up front so heap comparisons never touch `record`.
+pub(super) struct MappedRead {
     /// Alignment record (SAM/BAM/CRAM)
-    pub(super) record: RecordBuf,
+    pub(super) record: Box<dyn Record>,
 
     /// The deterministic key assigned to this record
     pub(super) key: u64,
 
+    /// Alignment start for the record (0-based)
+    pub(super) start: i64,
+
     /// Alignment end for the record (1-based inclusive)
     pub(super) end: i64,
+
+    /// Read name, extracted once so ordering never has to reach into `record`
+    pub(super) name: Vec<u8>,
 }
 
-impl ScoredRead {
-    pub(super) fn new(record: RecordBuf, key: u64, end: i64) -> Self {
-        Self { record, key, end }
+impl MappedRead {
+    pub(super) fn new(record: Box<dyn Record>, key: u64, start: i64, end: i64) -> Self {
+        let name = extract_name(&record);
+        Self {
+            record,
+            key,
+            start,
+            end,
+            name,
+        }
     }
 }
 
-impl PartialEq for ScoredRead {
+impl PartialEq for MappedRead {
     fn eq(&self, other: &Self) -> bool {
-        self.key == other.key && self.record.name() == other.record.name()
+        self.key == other.key && self.name == other.name
     }
 }
 
-impl Eq for ScoredRead {}
+impl Eq for MappedRead {}
 
-impl PartialOrd for ScoredRead {
+impl PartialOrd for MappedRead {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -37,10 +55,10 @@ impl PartialOrd for ScoredRead {
 
 // if the random key is equal (very rare),
 // then compare it based the qname record (which i think will be unique)
-impl Ord for ScoredRead {
+impl Ord for MappedRead {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match self.key.cmp(&other.key) {
-            std::cmp::Ordering::Equal => self.record.name().cmp(&other.record.name()),
+            std::cmp::Ordering::Equal => self.name.cmp(&other.name),
             std::cmp::Ordering::Greater => std::cmp::Ordering::Greater,
             std::cmp::Ordering::Less => std::cmp::Ordering::Less,
         }
@@ -50,44 +68,30 @@ impl Ord for ScoredRead {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noodles::sam::alignment::RecordBuf;
+
+    fn boxed(record: RecordBuf) -> Box<dyn Record> {
+        Box::new(record)
+    }
 
     #[test]
-    fn test_scored_read_ordering() {
-        let r1 = RecordBuf::default();
-        let small = ScoredRead {
-            record: r1,
-            key: 10,
-            end: 1000,
-        };
-
-        let r2 = RecordBuf::default();
-        let big = ScoredRead {
-            record: r2,
-            key: 99,
-            end: 1000,
-        };
+    fn test_mapped_read_ordering() {
+        let small = MappedRead::new(boxed(RecordBuf::default()), 10, 0, 1000);
+        let big = MappedRead::new(boxed(RecordBuf::default()), 99, 0, 1000);
 
         assert!(big > small, "Higher key should be 'Greater' in ordering");
         assert!(small < big, "Lower key should be 'Less' in ordering");
     }
 
     #[test]
-    fn test_scored_read_ordering_tie() {
+    fn test_mapped_read_ordering_tie() {
         let mut r1 = RecordBuf::default();
         *r1.name_mut() = Some("readA".parse().unwrap());
-        let record1 = ScoredRead {
-            record: r1,
-            key: 21,
-            end: 1000,
-        };
+        let record1 = MappedRead::new(boxed(r1), 21, 0, 1000);
 
         let mut r2 = RecordBuf::default();
         *r2.name_mut() = Some("readB".parse().unwrap());
-        let record2 = ScoredRead {
-            record: r2,
-            key: 21,
-            end: 1001,
-        };
+        let record2 = MappedRead::new(boxed(r2), 21, 0, 1001);
 
         assert!(record2 > record1);
     }
@@ -96,20 +100,12 @@ mod tests {
     fn test_equality_record() {
         let mut r1 = RecordBuf::default();
         *r1.name_mut() = Some("readA".parse().unwrap());
-        let record1 = ScoredRead {
-            record: r1.clone(),
-            key: 21,
-            end: 1000,
-        };
+        let record1 = MappedRead::new(boxed(r1), 21, 0, 1000);
 
         let mut r2 = RecordBuf::default();
         *r2.name_mut() = Some("readA".parse().unwrap());
-        let record2 = ScoredRead {
-            record: r2.clone(),
-            key: 21,
-            end: 1000,
-        };
+        let record2 = MappedRead::new(boxed(r2), 21, 0, 1000);
 
-        assert_eq!(record1, record2);
+        assert!(record1 == record2);
     }
 }

--- a/src/alignment/stream.rs
+++ b/src/alignment/stream.rs
@@ -1,17 +1,34 @@
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::BinaryHeap;
 
 use anyhow::{Context, Result};
 use log::{info, warn};
 
-use noodles::sam::alignment::RecordBuf;
 use noodles::sam::Header;
 use noodles_util::alignment;
 use rand::Rng;
 
 use super::args::Alignment;
 use super::io::AlignmentWriter;
-use super::model::ScoredRead;
-use super::util::extract_name;
+use super::model::MappedRead;
+use super::NameSet;
+
+/// Whether an active read has fully expired at the current scan position, meaning it can leave
+/// the active heap and be written out (its end lies at or before the current start).
+fn has_expired(mapped_read: &MappedRead, current_pos: i64) -> bool {
+    mapped_read.end <= current_pos
+}
+
+/// Whether a new candidate should evict the current worst (highest-key) read in a full heap: the
+/// candidate needs a better (lower) priority key, and must lie within the allowed swap distance
+/// of the read it would replace.
+fn should_swap(
+    worst: &MappedRead,
+    candidate_key: u64,
+    candidate_pos: i64,
+    swap_distance: i64,
+) -> bool {
+    candidate_key < worst.key && candidate_pos.saturating_sub(worst.start) <= swap_distance
+}
 
 impl Alignment {
     pub(super) fn run_stream(&self) -> Result<()> {
@@ -29,7 +46,8 @@ impl Alignment {
         let is_paired = self.check_pair()?;
         let target_depth = self.get_target_depth(is_paired) as usize;
 
-        let mut survivor_names: HashSet<Vec<u8>> = HashSet::new();
+        let mut survivor_names: NameSet =
+            NameSet::with_capacity_and_hasher(target_depth, Default::default());
 
         if is_paired {
             info!("Detected Paired-End data");
@@ -58,7 +76,7 @@ impl Alignment {
         &self,
         target_depth: usize,
         paired_mode: bool,
-        survivor_names: &mut HashSet<Vec<u8>>,
+        survivor_names: &mut NameSet,
         header: &Header,
         writer: &mut AlignmentWriter,
         rng: &mut rand_pcg::Pcg64,
@@ -71,10 +89,10 @@ impl Alignment {
 
         // the active set to store reads that currently in the scan
         // using max heap, it keeps the read with the highest key (worst priority) at the top.
-        let mut active_reads: BinaryHeap<ScoredRead> = BinaryHeap::with_capacity(target_depth);
+        let mut active_reads: BinaryHeap<MappedRead> = BinaryHeap::with_capacity(target_depth);
 
         // we also pre alocated a vector here, and will be reused
-        let mut survivors: Vec<ScoredRead> = Vec::with_capacity(target_depth);
+        let mut survivors: Vec<MappedRead> = Vec::with_capacity(target_depth);
 
         let mut current_tid: Option<usize> = None;
         let mut max_observed_depth: usize = 0;
@@ -155,15 +173,13 @@ impl Alignment {
                 // we still have survived reads from the previous chromosome in the heap,
                 // we need to write them
                 if current_tid.is_some() {
-                    for scored_read in &active_reads {
+                    for mapped_read in &active_reads {
                         // before we write into the result, we need to extract the read name
                         if paired_mode {
-                            let qname: Vec<u8> = extract_name(&scored_read.record);
-
-                            survivor_names.insert(qname);
+                            survivor_names.insert(mapped_read.name.clone());
                         }
                         writer
-                            .write_record(header, &scored_read.record)
+                            .write_record(header, &mapped_read.record)
                             .context("Failed to write record")?;
                     }
                 }
@@ -184,73 +200,49 @@ impl Alignment {
             // i use drain method: https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#method.drain
             survivors.extend(active_reads.drain());
 
-            for scored_read in survivors.drain(..) {
-                // inclusive end
-                if scored_read.end <= start {
+            for mapped_read in survivors.drain(..) {
+                if has_expired(&mapped_read, start) {
                     // the reads survived!
 
                     // before we write into the result, we need to extract the read name
                     if paired_mode {
-                        let qname: Vec<u8> = extract_name(&scored_read.record);
-
-                        survivor_names.insert(qname);
+                        survivor_names.insert(mapped_read.name.clone());
                     }
                     // and we write it into the result
                     writer
-                        .write_record(header, &scored_read.record)
+                        .write_record(header, &mapped_read.record)
                         .context("Failed to write record")?;
                 } else {
                     // still active,
                     // put it back in heap
-                    active_reads.push(scored_read);
+                    active_reads.push(mapped_read);
                 }
             }
 
             // note: survivors.drain(..) automatically clears the vector items but keeps the capacity.
             // with target depth usually 50 - 100 maybe, i think this operation is not very expensive.
 
-            if active_reads.len() < target_depth {
-                // calculate the end position only once here:
-                let end = record
-                    .alignment_end()
-                    .transpose()?
-                    .map(|e| usize::from(e) as i64)
-                    .unwrap_or(pos);
+            // calculate the end position only once here, regardless of whether the read is accepted:
+            let end = record
+                .alignment_end()
+                .transpose()?
+                .map(|e| usize::from(e) as i64)
+                .unwrap_or(pos);
 
-                // we convert to Recordbuf here before we want to push it to the heap
-                let record = RecordBuf::try_from_alignment_record(header, &record)?;
-                let new_read = ScoredRead::new(record, key, end);
+            if active_reads.len() < target_depth {
+                // the record is already owned (boxed by the reader), so no extra parsing is
+                // needed before it enters the heap
+                let new_read = MappedRead::new(record, key, start, end);
 
                 // if the heap has records fewer than N reads, just accept it.
                 active_reads.push(new_read);
             } else {
                 // if the heap is full, we only consider the new read if it has a better (lower) key
-                // than the current worst read in the haep
+                // than the current worst read in the heap, and lies within the swap distance
                 if let Some(mut worst) = active_reads.peek_mut() {
-                    // does the new record has better key?
-                    if key < worst.key {
-                        // calculate the distance between these two reads
-                        let worst_start = worst.record.alignment_start();
-                        let worst_pos = worst_start.map(|p| usize::from(p) as i64 - 1).unwrap_or(0);
-
-                        let distance = pos.saturating_sub(worst_pos);
-
-                        // are we allowed to swap these two reads given a specified swap distance?
-                        if distance <= self.swap_distance {
-                            // we swap the records
-                            // calculate the end position only once here:
-                            let end = record
-                                .alignment_end()
-                                .transpose()?
-                                .map(|e| usize::from(e) as i64)
-                                .unwrap_or(pos);
-
-                            // we convert to Recordbuf here before we want to swap it to the heap
-                            let record = RecordBuf::try_from_alignment_record(header, &record)?;
-                            let new_read = ScoredRead::new(record, key, end);
-                            // we swap the records
-                            *worst = new_read;
-                        }
+                    if should_swap(&worst, key, pos, self.swap_distance) {
+                        let new_read = MappedRead::new(record, key, start, end);
+                        *worst = new_read;
                     }
                 }
             }
@@ -267,15 +259,13 @@ impl Alignment {
 
         // any remaining read in the heap survive
         // write into the subsampled result.
-        for scored_read in active_reads {
+        for mapped_read in active_reads {
             // before we write into the result, we need to extract the read name
             if paired_mode {
-                let qname: Vec<u8> = extract_name(&scored_read.record);
-
-                survivor_names.insert(qname);
+                survivor_names.insert(mapped_read.name.clone());
             }
             writer
-                .write_record(header, &scored_read.record)
+                .write_record(header, &mapped_read.record)
                 .context("Failed to write record")?;
         }
 
@@ -287,9 +277,58 @@ impl Alignment {
 mod tests {
     use super::super::args::SubsamplingStrategy;
     use super::*;
+    use noodles::sam::alignment::{Record, RecordBuf};
     use noodles_util::alignment::io::Format;
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
+
+    fn mapped_read(key: u64, start: i64, end: i64) -> MappedRead {
+        let record: Box<dyn Record> = Box::new(RecordBuf::default());
+        MappedRead::new(record, key, start, end)
+    }
+
+    #[test]
+    fn test_has_expired_when_end_before_current_pos() {
+        let read = mapped_read(1, 0, 100);
+        assert!(has_expired(&read, 150));
+    }
+
+    #[test]
+    fn test_has_expired_when_end_equals_current_pos() {
+        // end is inclusive, so a read ending exactly at the scan position has expired
+        let read = mapped_read(1, 0, 100);
+        assert!(has_expired(&read, 100));
+    }
+
+    #[test]
+    fn test_not_expired_when_end_after_current_pos() {
+        let read = mapped_read(1, 0, 100);
+        assert!(!has_expired(&read, 99));
+    }
+
+    #[test]
+    fn test_should_swap_with_better_key_within_distance() {
+        let worst = mapped_read(50, 10, 100);
+        assert!(should_swap(&worst, 5, 12, 5));
+    }
+
+    #[test]
+    fn test_should_not_swap_with_worse_key() {
+        let worst = mapped_read(5, 10, 100);
+        assert!(!should_swap(&worst, 50, 12, 5));
+    }
+
+    #[test]
+    fn test_should_not_swap_beyond_swap_distance() {
+        let worst = mapped_read(50, 10, 100);
+        assert!(!should_swap(&worst, 5, 20, 5));
+    }
+
+    #[test]
+    fn test_should_swap_at_exact_swap_distance_boundary() {
+        let worst = mapped_read(50, 10, 100);
+        assert!(should_swap(&worst, 5, 15, 5));
+    }
 
     #[test]
     fn test_output_never_exceeds_target_depth() {

--- a/src/alignment/util.rs
+++ b/src/alignment/util.rs
@@ -1,20 +1,25 @@
-use noodles::sam::alignment::{Record, RecordBuf};
+use noodles::sam::alignment::Record;
 use rand::prelude::*;
 use rand::Rng;
 
-/// Sorts records by position and shuffles those with the same position
-pub(super) fn shuffle_records_by_position(records: &mut [&RecordBuf], rng: &mut impl Rng) {
-    // First sort by position
-    records.sort_by_key(|record| record.alignment_start());
+// treats a record with no start position the same as one whose start position failed to parse.
+// Used only from contexts (e.g. `partition_point`'s predicate) that can't propagate a `Result`;
+// callers that can propagate errors should prefer `record.alignment_start().transpose()?`.
+pub(super) fn alignment_start<R: Record>(record: &R) -> Option<noodles::core::Position> {
+    record.alignment_start().and_then(Result::ok)
+}
 
-    // Then shuffle groups with the same position
+/// Shuffles groups of records with the same position. Assumes `records` is already sorted by
+/// position (true of every caller: it's either a fresh position-sorted index query, or an
+/// already-sorted batch cache), so there's no need to pay for a redundant sort here.
+pub(super) fn shuffle_grouped_by_position<R: Record>(records: &mut [&R], rng: &mut impl Rng) {
     let mut start = 0;
     while start < records.len() {
-        let pos = records[start].alignment_start();
+        let pos = alignment_start(records[start]);
         let mut end = start + 1;
 
         // Find the end of the group with the same position
-        while end < records.len() && records[end].alignment_start() == pos {
+        while end < records.len() && alignment_start(records[end]) == pos {
             end += 1;
         }
 
@@ -42,6 +47,7 @@ pub(super) fn extract_name<R: Record>(record: &R) -> Vec<u8> {
 mod tests {
     use super::*;
     use noodles::core::Position;
+    use noodles::sam::alignment::RecordBuf;
     use rand::prelude::StdRng;
     use rand::RngExt;
 
@@ -50,7 +56,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(1234);
         let mut empty_records: Vec<&RecordBuf> = vec![];
 
-        shuffle_records_by_position(&mut empty_records, &mut rng);
+        shuffle_grouped_by_position(&mut empty_records, &mut rng);
 
         assert_eq!(empty_records.len(), 0);
     }
@@ -64,7 +70,7 @@ mod tests {
         *record.alignment_start_mut() = Position::new(100);
         let mut records: Vec<&RecordBuf> = vec![&record];
 
-        shuffle_records_by_position(&mut records, &mut rng);
+        shuffle_grouped_by_position(&mut records, &mut rng);
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].alignment_start(), Position::new(100));
@@ -74,19 +80,19 @@ mod tests {
     fn test_shuffle_records_by_position_maintains_sort_order() {
         let mut rng = StdRng::seed_from_u64(1234);
 
-        // Create records with different positions
+        // Create records with different positions, pre-sorted (as callers guarantee)
         let mut record1 = RecordBuf::default();
-        *record1.alignment_start_mut() = Position::new(300);
+        *record1.alignment_start_mut() = Position::new(100);
         let mut record2 = RecordBuf::default();
-        *record2.alignment_start_mut() = Position::new(100);
+        *record2.alignment_start_mut() = Position::new(200);
         let mut record3 = RecordBuf::default();
-        *record3.alignment_start_mut() = Position::new(200);
+        *record3.alignment_start_mut() = Position::new(300);
 
         let mut records = vec![&record1, &record2, &record3];
 
-        shuffle_records_by_position(&mut records, &mut rng);
+        shuffle_grouped_by_position(&mut records, &mut rng);
 
-        // Should be sorted by position
+        // Should still be sorted by position (single-element groups are untouched)
         assert_eq!(records.len(), 3);
         assert_eq!(records[0].alignment_start(), Position::new(100));
         assert_eq!(records[1].alignment_start(), Position::new(200));
@@ -120,7 +126,7 @@ mod tests {
         let mut different_orders = 0;
         for _ in 0..10 {
             let mut test_records = records.clone();
-            shuffle_records_by_position(&mut test_records, &mut rng);
+            shuffle_grouped_by_position(&mut test_records, &mut rng);
 
             // All should still be at position 100
             assert!(records
@@ -148,30 +154,31 @@ mod tests {
     fn test_shuffle_records_by_position_mixed_positions() {
         let mut rng = StdRng::seed_from_u64(1234);
 
-        // Create records with mixed positions - some same, some different
+        // Create records with mixed positions - some same, some different, pre-sorted (as callers
+        // guarantee)
         let mut record1 = RecordBuf::default();
         *record1.alignment_start_mut() = Position::new(100);
         *record1.name_mut() = Some("read1_pos100".parse().unwrap());
-
-        let mut record2 = RecordBuf::default();
-        *record2.alignment_start_mut() = Position::new(200);
-        *record2.name_mut() = Some("read2_pos200".parse().unwrap());
 
         let mut record3 = RecordBuf::default();
         *record3.alignment_start_mut() = Position::new(100);
         *record3.name_mut() = Some("read3_pos100".parse().unwrap());
 
-        let mut record4 = RecordBuf::default();
-        *record4.alignment_start_mut() = Position::new(150);
-        *record4.name_mut() = Some("read4_pos150".parse().unwrap());
-
         let mut record5 = RecordBuf::default();
         *record5.alignment_start_mut() = Position::new(100);
         *record5.name_mut() = Some("read5_pos100".parse().unwrap());
 
-        let mut records = vec![&record1, &record2, &record3, &record4, &record5];
+        let mut record4 = RecordBuf::default();
+        *record4.alignment_start_mut() = Position::new(150);
+        *record4.name_mut() = Some("read4_pos150".parse().unwrap());
 
-        shuffle_records_by_position(&mut records, &mut rng);
+        let mut record2 = RecordBuf::default();
+        *record2.alignment_start_mut() = Position::new(200);
+        *record2.name_mut() = Some("read2_pos200".parse().unwrap());
+
+        let mut records = vec![&record1, &record3, &record5, &record4, &record2];
+
+        shuffle_grouped_by_position(&mut records, &mut rng);
 
         // Should be sorted by position
         let positions: Vec<Position> = records
@@ -285,7 +292,7 @@ mod tests {
         let mut new_same_order_count = 0;
         for _ in 0..20 {
             let mut test_records = records.clone();
-            shuffle_records_by_position(&mut test_records, &mut rng);
+            shuffle_grouped_by_position(&mut test_records, &mut rng);
 
             let new_order: Vec<Vec<u8>> = test_records
                 .iter()


### PR DESCRIPTION
## Summary

Implements S6 of the runtime/memory optimisation plan (#170), closes #176.

- Replaces `ScoredRead` (which embedded a fully eager-parsed `RecordBuf`) with a lightweight `MappedRead` holding `key`/`start`/`end`/`name` plus the `Box<dyn Record>` the reader already owns. Heap/ordering comparisons never touch the record.
- Discovered that noodles-util 0.78's `reader.records()`/`query()` already return an owned `Box<dyn Record>` per record (not a lending/borrowed reference), and `Box<dyn Record>` implements `Record` (including being directly writable). So instead of "parse a RecordBuf only for survivors", the implementation never parses a RecordBuf in the hot path at all — stream.rs and fetch.rs's batch cache both keep the boxed record as-is until write time.
- Extracted the heap eviction/swap decision into two pure, unit-tested functions (`has_expired`, `should_swap`) — the "new seam" the issue asked to unit test with synthetic `MappedRead`s.
- Quick wins: `rustc-hash`-backed `NameSet` type alias for the qname sets (was default `SipHash`), pre-sized `survivor_names`, dropped the redundant re-sort in fetch's already position-sorted candidate batch (`shuffle_grouped_by_position`).
- "Reuse the candidates Vec" was attempted but reverted: hoisting it out of the position loop created a self-referential borrow-checker conflict against `batch_cache` that would require an index-based (`Vec<usize>`) redesign — judged not worth the complexity for this quick win.

Coordinate math previously duplicated in stream.rs (two identical `alignment_end()` conversions) and scattered `.unwrap_or(Position::MIN)` fallbacks in fetch.rs are now centralized through `util::alignment_start`.

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --all-targets` (165 lib tests incl. 7 new `has_expired`/`should_swap` unit tests, all integration tests, all reproducibility tests)
- [x] `cargo test --doc`
- [x] `reproducibility_aln_seed_42` (the byte-identical-output guard) passes unchanged
- [x] Two-axis code review (Standards + Spec) run; findings addressed (deduplicated inline coordinate fallback logic, fixed error-swallowing inconsistency between `flags()?` and position accessors, added the missing synthetic-`MappedRead` unit tests for eviction/swap logic)