### PR TITLE
ci: wire benches/bench.sh compare into a non-blocking PR check

### DIFF
--- a/.github/workflows/benchmark-pr.yaml
+++ b/.github/workflows/benchmark-pr.yaml
@@ -1,0 +1,69 @@
+on:
+  pull_request:
+    branches: [ main ]
+
+name: Benchmark PR
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  bench-compare:
+    name: Compare wall time / peak RSS vs main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+            ${{ runner.os }}-cargo-
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: hyperfine
+
+      - name: Install GNU time (peak RSS measurement)
+        run: sudo apt-get update && sudo apt-get install -y time
+
+      # This is a non-blocking, informational check: `bench.sh compare` exits non-zero
+      # when a scenario regresses past its threshold, but `continue-on-error` keeps that
+      # from failing the PR - see benches/README.md for why this is intentionally
+      # advisory rather than a hard gate.
+      - name: Compare current branch against main
+        id: bench
+        continue-on-error: true
+        run: benches/bench.sh compare origin/main | tee bench-compare.txt
+
+      - name: Add comparison to job summary
+        if: always()
+        env:
+          README_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/benches/README.md
+        run: |
+          {
+            echo "### Benchmark comparison vs \`origin/main\`"
+            echo
+            echo "Wall time / peak RSS, ratio = head / base. Informational only - see [benches/README.md]($README_URL)."
+            echo
+            echo '```'
+            cat bench-compare.txt 2>/dev/null || echo "(no output captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/benches/README.md
+++ b/benches/README.md
@@ -4,9 +4,11 @@ Two independent things live here:
 
 1. **`bench.sh`** - an internal A/B regression harness. Compares two git refs (or the
    current working tree) on wall time and peak RSS, for a fixed set of scenarios. Run it
-   locally to prove a change didn't regress performance before opening a PR. (No CI job
-   runs this automatically yet - `compare origin/main` is intended to be wired into a
-   non-blocking PR check in future, but that workflow doesn't exist yet.)
+   locally to prove a change didn't regress performance before opening a PR. It also runs
+   automatically on every PR via `.github/workflows/benchmark-pr.yaml`
+   (`compare origin/main`), which posts the comparison table to the job summary. That
+   check is intentionally non-blocking (advisory only) - a noisy shared CI runner isn't a
+   reliable enough signal to gate merges on.
 2. **`update_readme.sh`** - regenerates the tool-comparison tables in the top-level
    `README.md` (`rasusa` vs `filtlong`/`seqtk`). This downloads real public datasets and
    is run from a release-triggered GitHub Actions workflow


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark-pr.yaml`: runs `benches/bench.sh compare origin/main` on every PR targeting `main` and posts the wall-time/peak-RSS comparison table to the job summary.
- Intentionally non-blocking (`continue-on-error: true` on the compare step) — a shared, noisy CI runner isn't a reliable enough signal to hard-gate merges on, per the design already documented (but not yet implemented) in `benches/README.md`.
- Updates `benches/README.md` to reflect that this is now wired up.

## Test plan

- [x] Ran `benches/bench.sh compare origin/main` locally to confirm the script itself works as expected (used to produce the S6/#176 perf numbers)
- [ ] First real PR run will confirm the workflow itself (toolchain setup, `hyperfine`/GNU `time` install, job summary rendering) — can't fully dry-run a `pull_request`-triggered workflow locally