### PR TITLE
refactor(format): consolidate format/compression detection into one module

### DIFF
--- a/src/alignment/args.rs
+++ b/src/alignment/args.rs
@@ -4,8 +4,7 @@ use clap::{Parser, ValueEnum};
 use noodles_util::alignment::io::Format;
 
 use crate::cli::check_path_exists;
-
-use super::io::infer_format_from_char;
+use crate::format::infer_format_from_char;
 
 #[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
 pub enum SubsamplingStrategy {

--- a/src/alignment/header.rs
+++ b/src/alignment/header.rs
@@ -6,33 +6,31 @@ use noodles::sam::header::record::value::{
 };
 use noodles::sam::Header;
 
-use super::args::Alignment;
-
 const RASUSA: &str = "rasusa";
 
-impl Alignment {
-    /// Generates a rasusa program entry from a SAM header
-    pub fn program_entry(&self, header: &Header) -> (String, Map<Program>) {
-        let (program_id, previous_pgid) = make_program_id_unique(header, RASUSA);
+/// Generates a rasusa program entry from a SAM header. Shared by every code path that writes an
+/// alignment header (the `aln` subcommand and `reads`' [`crate::source::AlignmentSource`]), so
+/// the program-record shape only lives in one place.
+pub fn program_entry(header: &Header) -> (String, Map<Program>) {
+    let (program_id, previous_pgid) = make_program_id_unique(header, RASUSA);
 
-        // Creates a SAM header record map value
-        let mut record = Map::<Program>::builder();
+    // Creates a SAM header record map value
+    let mut record = Map::<Program>::builder();
 
-        record = record.insert(tag::NAME, RASUSA);
-        record = record.insert(tag::VERSION, env!("CARGO_PKG_VERSION"));
+    record = record.insert(tag::NAME, RASUSA);
+    record = record.insert(tag::VERSION, env!("CARGO_PKG_VERSION"));
 
-        let cl = std::env::args().collect::<Vec<String>>().join(" ");
-        record = record.insert(tag::COMMAND_LINE, cl);
+    let cl = std::env::args().collect::<Vec<String>>().join(" ");
+    record = record.insert(tag::COMMAND_LINE, cl);
 
-        // Link to previous program
-        if let Some(pp) = previous_pgid {
-            record = record.insert(tag::PREVIOUS_PROGRAM_ID, pp);
-        };
+    // Link to previous program
+    if let Some(pp) = previous_pgid {
+        record = record.insert(tag::PREVIOUS_PROGRAM_ID, pp);
+    };
 
-        let program = record.build().expect("Failed to build program record");
+    let program = record.build().expect("Failed to build program record");
 
-        (program_id.into_owned(), program)
-    }
+    (program_id.into_owned(), program)
 }
 
 /// Makes a program ID unique by looking for existing program records with the same ID and adding

--- a/src/alignment/io.rs
+++ b/src/alignment/io.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::io::{self, Write};
-use std::path::Path;
 
 use anyhow::{Context, Result};
 use log::info;
@@ -8,9 +7,12 @@ use rand::prelude::*;
 use rand::random;
 
 use noodles::sam::Header;
-use noodles_util::alignment::{self, io::Format};
+use noodles_util::alignment;
+
+use crate::format::infer_format_from_path;
 
 use super::args::Alignment;
+use super::header::program_entry;
 
 // a generic writer that can handle File or Stdout
 pub(super) type AlignmentWriter = alignment::io::Writer<Box<dyn Write>>;
@@ -33,7 +35,7 @@ impl Alignment {
         let mut header = input_header.clone();
 
         // add rasusa program command line to header
-        let (pg_id, pg_map) = self.program_entry(&header);
+        let (pg_id, pg_map) = program_entry(&header);
 
         // set up the header and writer
         header.programs_mut().as_mut().insert(pg_id.into(), pg_map);
@@ -83,71 +85,5 @@ impl Alignment {
         writer.write_header(&header)?;
 
         Ok((rng, writer))
-    }
-}
-
-pub fn infer_format_from_path(path: &Path) -> Option<Format> {
-    match path.extension().and_then(|ext| ext.to_str()) {
-        Some("sam") => Some(Format::Sam),
-        Some("bam") => Some(Format::Bam),
-        Some("cram") => Some(Format::Cram),
-        _ => None,
-    }
-}
-
-// a function which infers a format from a single character (case insensitive) this will be used in the CLI, so should return a Result
-pub fn infer_format_from_char(c: &str) -> Result<Format, String> {
-    match c.to_ascii_lowercase().as_str() {
-        "s" | "sam" => Ok(Format::Sam),
-        "b" | "bam" => Ok(Format::Bam),
-        "c" | "cram" => Ok(Format::Cram),
-        _ => Err(String::from("Invalid output format. Please use 's', 'b', or 'c' to specify SAM, BAM, or CRAM format, respectively")),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_infer_format() {
-        let fmt = infer_format_from_path(Path::new("file.sam")).unwrap();
-        assert!(matches!(fmt, Format::Sam));
-
-        let fmt = infer_format_from_path(Path::new("file.bam")).unwrap();
-        assert!(matches!(fmt, Format::Bam));
-
-        let fmt = infer_format_from_path(Path::new("file.cram")).unwrap();
-        assert!(matches!(fmt, Format::Cram));
-
-        let fmt = infer_format_from_path(Path::new("file.txt"));
-        assert!(fmt.is_none());
-    }
-
-    #[test]
-    fn test_infer_format_from_char() {
-        let fmt = infer_format_from_char("s").unwrap();
-        assert!(matches!(fmt, Format::Sam));
-
-        let fmt = infer_format_from_char("b").unwrap();
-        assert!(matches!(fmt, Format::Bam));
-
-        let fmt = infer_format_from_char("c").unwrap();
-        assert!(matches!(fmt, Format::Cram));
-
-        let fmt = infer_format_from_char("x");
-        assert!(fmt.is_err());
-
-        let fmt = infer_format_from_char("sam").unwrap();
-        assert!(matches!(fmt, Format::Sam));
-
-        let fmt = infer_format_from_char("B").unwrap();
-        assert!(matches!(fmt, Format::Bam));
-
-        let fmt = infer_format_from_char("CRAM").unwrap();
-        assert!(matches!(fmt, Format::Cram));
-
-        let fmt = infer_format_from_char("x");
-        assert!(fmt.is_err());
     }
 }

--- a/src/alignment/mod.rs
+++ b/src/alignment/mod.rs
@@ -7,8 +7,7 @@ mod stream;
 mod util;
 
 pub use args::{Alignment, SubsamplingStrategy};
-pub use header::make_program_id_unique;
-pub use io::{infer_format_from_char, infer_format_from_path};
+pub use header::{make_program_id_unique, program_entry};
 
 use std::collections::HashSet;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -418,24 +418,6 @@ impl Mul<GenomeSize> for Coverage {
     }
 }
 
-pub trait CompressionExt {
-    fn from_path<S: AsRef<OsStr> + ?Sized>(p: &S) -> Self;
-}
-
-impl CompressionExt for niffler::compression::Format {
-    /// Attempts to infer the compression type from the file extension. If the extension is not
-    /// known, then Uncompressed is returned.
-    fn from_path<S: AsRef<OsStr> + ?Sized>(p: &S) -> Self {
-        let path = Path::new(p);
-        match path.extension().map(|s| s.to_str()) {
-            Some(Some("gz")) => Self::Gzip,
-            Some(Some("bz") | Some("bz2")) => Self::Bzip,
-            Some(Some("lzma")) => Self::Lzma,
-            _ => Self::No,
-        }
-    }
-}
-
 pub(crate) fn parse_compression_format(s: &str) -> Result<niffler::compression::Format, CliError> {
     match s {
         "b" | "B" => Ok(niffler::Format::Bzip),
@@ -925,28 +907,5 @@ pub(crate) mod tests {
         assert!(parse_level("f").is_err());
         assert!(parse_level("5.5").is_err());
         assert!(parse_level("-3").is_err());
-    }
-
-    #[test]
-    fn compression_format_from_path() {
-        assert_eq!(niffler::Format::from_path("foo.gz"), niffler::Format::Gzip);
-        assert_eq!(
-            niffler::Format::from_path(Path::new("foo.gz")),
-            niffler::Format::Gzip
-        );
-        assert_eq!(niffler::Format::from_path("baz"), niffler::Format::No);
-        assert_eq!(niffler::Format::from_path("baz.fq"), niffler::Format::No);
-        assert_eq!(
-            niffler::Format::from_path("baz.fq.bz2"),
-            niffler::Format::Bzip
-        );
-        assert_eq!(
-            niffler::Format::from_path("baz.fq.bz"),
-            niffler::Format::Bzip
-        );
-        assert_eq!(
-            niffler::Format::from_path("baz.fq.lzma"),
-            niffler::Format::Lzma
-        );
     }
 }

--- a/src/fastx.rs
+++ b/src/fastx.rs
@@ -1,7 +1,6 @@
-use crate::cli::CompressionExt;
+use crate::format::OutputEncoding;
 use crate::source::RecordSource;
 use needletail::errors::ParseErrorKind::EmptyFile;
-use niffler::compression;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -177,9 +176,18 @@ impl RecordSource for Fastx {
         reads_to_keep: &[bool],
         nb_reads_keep: usize,
         write_to: &mut dyn Write,
-        _output_format: Option<noodles_util::alignment::io::Format>,
-        is_fasta: bool,
+        encoding: OutputEncoding,
     ) -> Result<usize, FastxError> {
+        // Callers never ask a FASTA/Q source for alignment-format output (`Reads::run` rejects
+        // that combination before any `RecordSource` is touched), so this is the only branch
+        // this impl needs to handle.
+        let is_fasta = match encoding {
+            OutputEncoding::Fastx { fasta } => fasta,
+            OutputEncoding::Alignment(_) => {
+                unreachable!("fastx sources never receive alignment output encoding")
+            }
+        };
+
         let mut total_len = 0;
 
         let (reader, _) = niffler::send::from_path(&self.path)?;
@@ -256,14 +264,9 @@ pub fn create_output_writer(
 ) -> Result<Box<dyn Write>, FastxError> {
     let file = File::create(path).map_err(|source| FastxError::CreateError { source })?;
     let file_handle = Box::new(BufWriter::new(file));
-    let fmt = compression_fmt.unwrap_or_else(|| niffler::Format::from_path(path));
-    let compression_lvl = compression_lvl.unwrap_or(match fmt {
-        compression::Format::Gzip => compression::Level::Six,
-        compression::Format::Bzip => compression::Level::Nine,
-        compression::Format::Lzma => compression::Level::Six,
-        compression::Format::Zstd => compression::Level::Three,
-        _ => compression::Level::Zero,
-    });
+    let fmt = compression_fmt.unwrap_or_else(|| crate::format::infer_compression_format(path));
+    let compression_lvl =
+        compression_lvl.unwrap_or_else(|| crate::format::default_compression_level(fmt));
     niffler::get_writer(file_handle, fmt, compression_lvl).map_err(FastxError::CompressOutputError)
 }
 
@@ -371,7 +374,12 @@ mod tests {
         let reads_to_keep: Vec<bool> = vec![false];
         let output = Builder::new().suffix(".fastq").tempfile().unwrap();
         let mut out_fh = create_output_writer(output.path(), None, None).unwrap();
-        let filter_result = fastx.filter_reads_into(&reads_to_keep, 0, &mut out_fh, None, false);
+        let filter_result = fastx.filter_reads_into(
+            &reads_to_keep,
+            0,
+            &mut out_fh,
+            OutputEncoding::Fastx { fasta: false },
+        );
 
         assert!(filter_result.is_ok());
 
@@ -392,8 +400,12 @@ mod tests {
         let output = Builder::new().suffix(".fastq").tempfile().unwrap();
         {
             let mut out_fh = create_output_writer(output.path(), None, None).unwrap();
-            let filter_result =
-                fastx.filter_reads_into(&reads_to_keep, 1, &mut out_fh, None, false);
+            let filter_result = fastx.filter_reads_into(
+                &reads_to_keep,
+                1,
+                &mut out_fh,
+                OutputEncoding::Fastx { fasta: false },
+            );
             assert!(filter_result.is_ok());
         }
 
@@ -413,7 +425,12 @@ mod tests {
         let output = Builder::new().suffix(".fa").tempfile().unwrap();
         {
             let mut out_fh = create_output_writer(output.path(), None, None).unwrap();
-            let filter_result = fastx.filter_reads_into(&reads_to_keep, 1, &mut out_fh, None, true);
+            let filter_result = fastx.filter_reads_into(
+                &reads_to_keep,
+                1,
+                &mut out_fh,
+                OutputEncoding::Fastx { fasta: true },
+            );
             assert!(filter_result.is_ok());
         }
 
@@ -433,8 +450,12 @@ mod tests {
         let output = Builder::new().suffix(".fastq").tempfile().unwrap();
         {
             let mut out_fh = create_output_writer(output.path(), None, None).unwrap();
-            let filter_result =
-                fastx.filter_reads_into(&reads_to_keep, 1, &mut out_fh, None, false);
+            let filter_result = fastx.filter_reads_into(
+                &reads_to_keep,
+                1,
+                &mut out_fh,
+                OutputEncoding::Fastx { fasta: false },
+            );
             assert!(filter_result.is_ok());
         }
 
@@ -454,8 +475,12 @@ mod tests {
         let output = Builder::new().suffix(".fastq").tempfile().unwrap();
         {
             let mut out_fh = create_output_writer(output.path(), None, None).unwrap();
-            let filter_result =
-                fastx.filter_reads_into(&reads_to_keep, 2, &mut out_fh, None, false);
+            let filter_result = fastx.filter_reads_into(
+                &reads_to_keep,
+                2,
+                &mut out_fh,
+                OutputEncoding::Fastx { fasta: false },
+            );
             assert!(filter_result.is_ok());
         }
 
@@ -476,7 +501,12 @@ mod tests {
         {
             let mut out_fh =
                 create_output_writer(output.path(), Some(niffler::Level::Four), None).unwrap();
-            let filter_result = fastx.filter_reads_into(&reads_to_keep, 2, &mut out_fh, None, true);
+            let filter_result = fastx.filter_reads_into(
+                &reads_to_keep,
+                2,
+                &mut out_fh,
+                OutputEncoding::Fastx { fasta: true },
+            );
             assert!(filter_result.is_err());
         }
 
@@ -497,8 +527,12 @@ mod tests {
         {
             let mut out_fh =
                 create_output_writer(output.path(), Some(niffler::Level::Four), None).unwrap();
-            let filter_result =
-                fastx.filter_reads_into(&reads_to_keep, 2, &mut out_fh, None, false);
+            let filter_result = fastx.filter_reads_into(
+                &reads_to_keep,
+                2,
+                &mut out_fh,
+                OutputEncoding::Fastx { fasta: false },
+            );
             assert!(filter_result.is_err());
         }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,256 @@
+//! Single source of truth for file-format/compression detection and the mappings derived from
+//! it. Before this module existed, extension->format detection, the compression-level defaults,
+//! and the `OutputFormat`->noodles `Format` mapping were each duplicated across `reads.rs`,
+//! `fastx.rs`, and `alignment/io.rs`, with no guarantee the copies agreed.
+
+use std::path::Path;
+
+use niffler::compression;
+use noodles_util::alignment::io::Format;
+
+use crate::cli::OutputFormat;
+
+/// What [`crate::source::RecordSource::filter_reads_into`] should encode records as. Threading
+/// this through (rather than a raw `Option<Format>` + `bool` pair) means implementations that
+/// can never receive alignment output (e.g. [`crate::fastx::Fastx`]) don't need to reason about
+/// the noodles `Format` type at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputEncoding {
+    /// Write as SAM/BAM/CRAM.
+    Alignment(Format),
+    /// Write as FASTA (`fasta: true`) or FASTQ (`fasta: false`).
+    Fastx { fasta: bool },
+}
+
+/// Infers an alignment [`Format`] from a path's extension (`.sam`/`.bam`/`.cram`).
+pub fn infer_format_from_path(path: &Path) -> Option<Format> {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("sam") => Some(Format::Sam),
+        Some("bam") => Some(Format::Bam),
+        Some("cram") => Some(Format::Cram),
+        _ => None,
+    }
+}
+
+/// Infers an alignment [`Format`] from a single character/word (case-insensitive), for CLI
+/// value parsing.
+pub fn infer_format_from_char(c: &str) -> Result<Format, String> {
+    match c.to_ascii_lowercase().as_str() {
+        "s" | "sam" => Ok(Format::Sam),
+        "b" | "bam" => Ok(Format::Bam),
+        "c" | "cram" => Ok(Format::Cram),
+        _ => Err(String::from("Invalid output format. Please use 's', 'b', or 'c' to specify SAM, BAM, or CRAM format, respectively")),
+    }
+}
+
+/// Whether `path` names a FASTA file, based on its extension (a trailing compression extension
+/// such as `.gz` is stripped first).
+pub fn is_fasta_extension(path: &Path) -> bool {
+    let mut p = path.to_path_buf();
+    if let Some(ext) = p.extension().map(|e| e.to_string_lossy().to_lowercase()) {
+        if ["gz", "bz2", "xz", "zst", "bz"].contains(&ext.as_str()) {
+            p = p.with_extension("");
+        }
+    }
+    if let Some(ext) = p.extension().map(|e| e.to_string_lossy().to_lowercase()) {
+        return ext == "fasta" || ext == "fa";
+    }
+    false
+}
+
+/// Whether output should be written as FASTA, given an explicit `--output-format` (if any) and a
+/// path to fall back to extension-based detection with when no explicit choice was made.
+pub fn is_fasta_output(output_format: Option<&OutputFormat>, fallback_path: &Path) -> bool {
+    match output_format {
+        Some(OutputFormat::Fasta) => true,
+        Some(OutputFormat::Fastq) => false,
+        _ => is_fasta_extension(fallback_path),
+    }
+}
+
+/// Maps a CLI-level `--output-format` selection to the noodles alignment [`Format`] it
+/// corresponds to. Returns `None` for FASTA/FASTQ selections or when no `--output-format` was
+/// given - callers fall back to extension-based inference ([`infer_format_from_path`]) in that
+/// case.
+pub fn output_alignment_format(output_format: Option<&OutputFormat>) -> Option<Format> {
+    match output_format {
+        Some(OutputFormat::Sam) => Some(Format::Sam),
+        Some(OutputFormat::Bam) => Some(Format::Bam),
+        Some(OutputFormat::Cram) => Some(Format::Cram),
+        Some(OutputFormat::Fasta) | Some(OutputFormat::Fastq) | None => None,
+    }
+}
+
+/// Infers a compression format from a path's extension (e.g. `.gz` -> Gzip), falling back to
+/// [`compression::Format::No`] for an unrecognised or absent extension.
+pub fn infer_compression_format(path: &Path) -> compression::Format {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("gz") => compression::Format::Gzip,
+        Some("bz") | Some("bz2") => compression::Format::Bzip,
+        Some("lzma") => compression::Format::Lzma,
+        _ => compression::Format::No,
+    }
+}
+
+/// The default compression level rasusa uses for a given compression format, when the user
+/// hasn't requested a specific level.
+pub fn default_compression_level(fmt: compression::Format) -> compression::Level {
+    match fmt {
+        compression::Format::Gzip => compression::Level::Six,
+        compression::Format::Bzip => compression::Level::Nine,
+        compression::Format::Lzma => compression::Level::Six,
+        compression::Format::Zstd => compression::Level::Three,
+        _ => compression::Level::Zero,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_compression_format() {
+        assert_eq!(
+            infer_compression_format(Path::new("foo.gz")),
+            compression::Format::Gzip
+        );
+        assert_eq!(
+            infer_compression_format(Path::new("baz")),
+            compression::Format::No
+        );
+        assert_eq!(
+            infer_compression_format(Path::new("baz.fq")),
+            compression::Format::No
+        );
+        assert_eq!(
+            infer_compression_format(Path::new("baz.fq.bz2")),
+            compression::Format::Bzip
+        );
+        assert_eq!(
+            infer_compression_format(Path::new("baz.fq.bz")),
+            compression::Format::Bzip
+        );
+        assert_eq!(
+            infer_compression_format(Path::new("baz.fq.lzma")),
+            compression::Format::Lzma
+        );
+    }
+
+    #[test]
+    fn test_infer_format() {
+        let fmt = infer_format_from_path(Path::new("file.sam")).unwrap();
+        assert!(matches!(fmt, Format::Sam));
+
+        let fmt = infer_format_from_path(Path::new("file.bam")).unwrap();
+        assert!(matches!(fmt, Format::Bam));
+
+        let fmt = infer_format_from_path(Path::new("file.cram")).unwrap();
+        assert!(matches!(fmt, Format::Cram));
+
+        let fmt = infer_format_from_path(Path::new("file.txt"));
+        assert!(fmt.is_none());
+    }
+
+    #[test]
+    fn test_infer_format_from_char() {
+        let fmt = infer_format_from_char("s").unwrap();
+        assert!(matches!(fmt, Format::Sam));
+
+        let fmt = infer_format_from_char("b").unwrap();
+        assert!(matches!(fmt, Format::Bam));
+
+        let fmt = infer_format_from_char("c").unwrap();
+        assert!(matches!(fmt, Format::Cram));
+
+        let fmt = infer_format_from_char("x");
+        assert!(fmt.is_err());
+
+        let fmt = infer_format_from_char("sam").unwrap();
+        assert!(matches!(fmt, Format::Sam));
+
+        let fmt = infer_format_from_char("B").unwrap();
+        assert!(matches!(fmt, Format::Bam));
+
+        let fmt = infer_format_from_char("CRAM").unwrap();
+        assert!(matches!(fmt, Format::Cram));
+
+        let fmt = infer_format_from_char("x");
+        assert!(fmt.is_err());
+    }
+
+    #[test]
+    fn test_is_fasta_extension() {
+        assert!(is_fasta_extension(Path::new("reads.fasta")));
+        assert!(is_fasta_extension(Path::new("reads.fa")));
+        assert!(is_fasta_extension(Path::new("reads.fa.gz")));
+        assert!(!is_fasta_extension(Path::new("reads.fastq")));
+        assert!(!is_fasta_extension(Path::new("reads.fq.gz")));
+    }
+
+    #[test]
+    fn test_is_fasta_output_explicit_overrides_fallback_path() {
+        assert!(is_fasta_output(
+            Some(&OutputFormat::Fasta),
+            Path::new("reads.fastq")
+        ));
+        assert!(!is_fasta_output(
+            Some(&OutputFormat::Fastq),
+            Path::new("reads.fasta")
+        ));
+    }
+
+    #[test]
+    fn test_is_fasta_output_falls_back_to_path_extension() {
+        assert!(is_fasta_output(None, Path::new("reads.fasta")));
+        assert!(!is_fasta_output(None, Path::new("reads.fastq")));
+        // Sam/Bam/Cram aren't Fasta/Fastq, so this also falls back to the path extension - the
+        // resulting bool is only ever consulted by callers when the *output encoding* is Fastx.
+        assert!(is_fasta_output(
+            Some(&OutputFormat::Sam),
+            Path::new("reads.fasta")
+        ));
+    }
+
+    #[test]
+    fn test_output_alignment_format() {
+        assert_eq!(
+            output_alignment_format(Some(&OutputFormat::Sam)),
+            Some(Format::Sam)
+        );
+        assert_eq!(
+            output_alignment_format(Some(&OutputFormat::Bam)),
+            Some(Format::Bam)
+        );
+        assert_eq!(
+            output_alignment_format(Some(&OutputFormat::Cram)),
+            Some(Format::Cram)
+        );
+        assert_eq!(output_alignment_format(Some(&OutputFormat::Fasta)), None);
+        assert_eq!(output_alignment_format(Some(&OutputFormat::Fastq)), None);
+        assert_eq!(output_alignment_format(None), None);
+    }
+
+    #[test]
+    fn test_default_compression_level() {
+        assert_eq!(
+            default_compression_level(compression::Format::Gzip),
+            compression::Level::Six
+        );
+        assert_eq!(
+            default_compression_level(compression::Format::Bzip),
+            compression::Level::Nine
+        );
+        assert_eq!(
+            default_compression_level(compression::Format::Lzma),
+            compression::Level::Six
+        );
+        assert_eq!(
+            default_compression_level(compression::Format::Zstd),
+            compression::Level::Three
+        );
+        assert_eq!(
+            default_compression_level(compression::Format::No),
+            compression::Level::Zero
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 pub mod alignment;
 pub mod cli;
 pub mod fastx;
+pub mod format;
 pub mod reads;
 pub mod source;
 pub mod subsampler;

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -3,14 +3,17 @@ use crate::cli::{
     GenomeSize,
 };
 use crate::fastx::create_output_writer;
+use crate::format::{
+    default_compression_level, infer_format_from_path, is_fasta_output, output_alignment_format,
+    OutputEncoding,
+};
 use crate::source::{determine_record_source, RecordSource};
 use crate::{Runner, SubSampler, SubsampleMode};
 use anyhow::{Context, Result};
 use clap::Parser;
 use log::{debug, info, warn};
-use niffler::compression;
 use std::io::{stdout, BufWriter};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
@@ -157,33 +160,18 @@ impl Runner for Reads {
         }
 
         let input_source = determine_record_source(&self.input[0]);
-        let input_format = crate::alignment::infer_format_from_path(&self.input[0]);
+        let input_format = infer_format_from_path(&self.input[0]);
 
         let check_conversion = |in_fmt: Option<noodles_util::alignment::io::Format>,
                                 out_path: Option<&std::path::PathBuf>|
          -> Result<()> {
             if in_fmt.is_none() {
-                let has_alignment_output = match &self.output_format {
-                    Some(crate::cli::OutputFormat::Sam)
-                    | Some(crate::cli::OutputFormat::Bam)
-                    | Some(crate::cli::OutputFormat::Cram) => true,
-                    _ => out_path
-                        .map(|p| crate::alignment::infer_format_from_path(p).is_some())
-                        .unwrap_or(false),
-                };
+                let explicit_out_fmt = output_alignment_format(self.output_format.as_ref());
+                let inferred_out_fmt = out_path.and_then(|p| infer_format_from_path(p));
+                let has_alignment_output = explicit_out_fmt.is_some() || inferred_out_fmt.is_some();
+
                 if has_alignment_output {
-                    let out_fmt = match &self.output_format {
-                        Some(crate::cli::OutputFormat::Sam) => {
-                            noodles_util::alignment::io::Format::Sam
-                        }
-                        Some(crate::cli::OutputFormat::Bam) => {
-                            noodles_util::alignment::io::Format::Bam
-                        }
-                        Some(crate::cli::OutputFormat::Cram) => {
-                            noodles_util::alignment::io::Format::Cram
-                        }
-                        _ => crate::alignment::infer_format_from_path(out_path.unwrap()).unwrap(),
-                    };
+                    let out_fmt = explicit_out_fmt.or(inferred_out_fmt).unwrap();
                     return Err(anyhow::anyhow!(
                         "Conversion from FASTA/FASTQ to {:?} is not supported. Please use FASTA/FASTQ output for FASTA/FASTQ input.",
                         out_fmt
@@ -195,7 +183,7 @@ impl Runner for Reads {
 
         check_conversion(input_format, self.output.first())?;
         if is_paired {
-            let second_input_format = crate::alignment::infer_format_from_path(&self.input[1]);
+            let second_input_format = infer_format_from_path(&self.input[1]);
             check_conversion(second_input_format, self.output.get(1))?;
         }
 
@@ -203,13 +191,7 @@ impl Runner for Reads {
             0 => match self.compress_type {
                 None => Box::new(BufWriter::new(stdout().lock())) as Box<dyn std::io::Write>,
                 Some(fmt) => {
-                    let lvl = match fmt {
-                        compression::Format::Gzip => compression::Level::Six,
-                        compression::Format::Bzip => compression::Level::Nine,
-                        compression::Format::Lzma => compression::Level::Six,
-                        compression::Format::Zstd => compression::Level::Three,
-                        _ => compression::Level::Zero,
-                    };
+                    let lvl = default_compression_level(fmt);
                     niffler::basic::get_writer(Box::new(BufWriter::new(stdout().lock())), fmt, lvl)?
                 }
             },
@@ -246,7 +228,7 @@ impl Reads {
         output_handle: &mut dyn std::io::Write,
     ) -> Result<()> {
         let is_paired = second_input_source.is_some();
-        let input_format = crate::alignment::infer_format_from_path(&self.input[0]);
+        let input_format = infer_format_from_path(&self.input[0]);
 
         let target_total_bases: Option<u64> = match (self.genome_size, self.coverage, self.bases) {
             (_, _, Some(bases)) => Some(u64::from(bases)),
@@ -390,28 +372,24 @@ impl Reads {
             );
         }
 
-        let output_format_1 = match &self.output_format {
-            Some(crate::cli::OutputFormat::Sam) => Some(noodles_util::alignment::io::Format::Sam),
-            Some(crate::cli::OutputFormat::Bam) => Some(noodles_util::alignment::io::Format::Bam),
-            Some(crate::cli::OutputFormat::Cram) => Some(noodles_util::alignment::io::Format::Cram),
-            Some(crate::cli::OutputFormat::Fasta) | Some(crate::cli::OutputFormat::Fastq) => None,
-            None => {
-                if self.output.is_empty() {
-                    input_format
-                } else {
-                    crate::alignment::infer_format_from_path(&self.output[0])
-                }
+        let output_format_1 = output_alignment_format(self.output_format.as_ref()).or_else(|| {
+            if self.output.is_empty() {
+                input_format
+            } else {
+                infer_format_from_path(&self.output[0])
             }
-        };
+        });
 
-        let is_fasta_1 = match self.output_format {
-            Some(crate::cli::OutputFormat::Fasta) => true,
-            Some(crate::cli::OutputFormat::Fastq) => false,
-            _ => {
-                if self.output.is_empty() {
-                    is_fasta_path(&self.input[0])
+        let encoding_1 = match output_format_1 {
+            Some(fmt) => OutputEncoding::Alignment(fmt),
+            None => {
+                let fallback_path = if self.output.is_empty() {
+                    &self.input[0]
                 } else {
-                    is_fasta_path(&self.output[0])
+                    &self.output[0]
+                };
+                OutputEncoding::Fastx {
+                    fasta: is_fasta_output(self.output_format.as_ref(), fallback_path),
                 }
             }
         };
@@ -420,48 +398,36 @@ impl Reads {
             &reads_to_keep,
             nb_reads_to_keep,
             output_handle,
-            output_format_1,
-            is_fasta_1,
+            encoding_1,
         )? as u64;
 
         // repeat the same process for the second input (if illumina)
         if let Some(second_input_source) = second_input_source {
-            let second_input_format = crate::alignment::infer_format_from_path(&self.input[1]);
+            let second_input_format = infer_format_from_path(&self.input[1]);
 
             let mut second_output_handle =
                 create_output_writer(&self.output[1], self.compress_level, self.compress_type)
                     .context("unable to create the second output file")?;
 
-            let output_format_2 = match &self.output_format {
-                Some(crate::cli::OutputFormat::Sam) => {
-                    Some(noodles_util::alignment::io::Format::Sam)
-                }
-                Some(crate::cli::OutputFormat::Bam) => {
-                    Some(noodles_util::alignment::io::Format::Bam)
-                }
-                Some(crate::cli::OutputFormat::Cram) => {
-                    Some(noodles_util::alignment::io::Format::Cram)
-                }
-                Some(crate::cli::OutputFormat::Fasta) | Some(crate::cli::OutputFormat::Fastq) => {
-                    None
-                }
-                None => {
+            let output_format_2 =
+                output_alignment_format(self.output_format.as_ref()).or_else(|| {
                     if self.output.len() < 2 {
                         second_input_format
                     } else {
-                        crate::alignment::infer_format_from_path(&self.output[1])
+                        infer_format_from_path(&self.output[1])
                     }
-                }
-            };
+                });
 
-            let is_fasta_2 = match self.output_format {
-                Some(crate::cli::OutputFormat::Fasta) => true,
-                Some(crate::cli::OutputFormat::Fastq) => false,
-                _ => {
-                    if self.output.len() < 2 {
-                        is_fasta_path(&self.input[1])
+            let encoding_2 = match output_format_2 {
+                Some(fmt) => OutputEncoding::Alignment(fmt),
+                None => {
+                    let fallback_path = if self.output.len() < 2 {
+                        &self.input[1]
                     } else {
-                        is_fasta_path(&self.output[1])
+                        &self.output[1]
+                    };
+                    OutputEncoding::Fastx {
+                        fasta: is_fasta_output(self.output_format.as_ref(), fallback_path),
                     }
                 }
             };
@@ -470,8 +436,7 @@ impl Reads {
                 &reads_to_keep,
                 nb_reads_to_keep,
                 &mut second_output_handle,
-                output_format_2,
-                is_fasta_2,
+                encoding_2,
             )? as u64;
         }
 
@@ -514,19 +479,6 @@ fn check_paired_counts(first_count: usize, second_count: usize) -> Result<()> {
         first_count
     );
     Ok(())
-}
-
-fn is_fasta_path(path: &Path) -> bool {
-    let mut p = path.to_path_buf();
-    if let Some(ext) = p.extension().map(|e| e.to_string_lossy().to_lowercase()) {
-        if ["gz", "bz2", "xz", "zst", "bz"].contains(&ext.as_str()) {
-            p = p.with_extension("");
-        }
-    }
-    if let Some(ext) = p.extension().map(|e| e.to_string_lossy().to_lowercase()) {
-        return ext == "fasta" || ext == "fa";
-    }
-    false
 }
 
 #[cfg(test)]

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,9 +1,9 @@
-use crate::alignment::make_program_id_unique;
+use crate::alignment::program_entry;
 use crate::fastx::{Fastx, FastxError};
+use crate::format::OutputEncoding;
 use anyhow::Result;
-use noodles::sam::header::record::value::map::{program::tag, Program};
-use noodles::sam::header::record::value::Map;
-use noodles_util::alignment::io::Format;
+use noodles::sam::alignment::record::Flags;
+use noodles::sam::alignment::Record;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -18,8 +18,7 @@ pub trait RecordSource {
         reads_to_keep: &[bool],
         nb_reads_keep: usize,
         write_to: &mut dyn Write,
-        output_format: Option<Format>,
-        is_fasta: bool,
+        encoding: OutputEncoding,
     ) -> Result<usize, FastxError>;
 }
 
@@ -33,23 +32,41 @@ impl AlignmentSource {
             path: path.to_path_buf(),
         }
     }
+}
 
-    fn program_entry(&self, header: &noodles::sam::Header) -> (String, Map<Program>) {
-        let (program_id, previous_pgid) = make_program_id_unique(header, "rasusa");
+/// Assigns a stable per-template index to alignment records, coalescing segmented (paired)
+/// records that share a QNAME onto the same index the way SAM template grouping expects.
+/// Indices are handed out sequentially (`0, 1, 2, ...`) in first-seen order, so `next_idx` at any
+/// point also equals the number of distinct templates seen so far.
+///
+/// Every alignment-format scan in this module (`read_lengths`, `count`, `filter_reads_into`)
+/// needs exactly this grouping, so it's centralised here rather than reimplemented per scan.
+#[derive(Default)]
+struct TemplateIndexer {
+    next_idx: usize,
+    qname_to_idx: HashMap<Vec<u8>, usize>,
+}
 
-        let mut record = Map::<Program>::builder();
-        record = record.insert(tag::NAME, "rasusa");
-        record = record.insert(tag::VERSION, env!("CARGO_PKG_VERSION"));
+impl TemplateIndexer {
+    fn index_for(&mut self, record: &dyn Record, flags: Flags) -> usize {
+        if !flags.is_segmented() {
+            let idx = self.next_idx;
+            self.next_idx += 1;
+            return idx;
+        }
 
-        let cl = std::env::args().collect::<Vec<String>>().join(" ");
-        record = record.insert(tag::COMMAND_LINE, cl);
+        let name = record
+            .name()
+            .map(|n| (n.as_ref() as &[u8]).to_vec())
+            .unwrap_or_default();
 
-        if let Some(pp) = previous_pgid {
-            record = record.insert(tag::PREVIOUS_PROGRAM_ID, pp);
-        };
-
-        let program = record.build().expect("Failed to build program record");
-        (program_id.into_owned(), program)
+        if let Some(&idx) = self.qname_to_idx.get(&name) {
+            return idx;
+        }
+        let idx = self.next_idx;
+        self.next_idx += 1;
+        self.qname_to_idx.insert(name, idx);
+        idx
     }
 }
 
@@ -64,7 +81,7 @@ impl RecordSource for AlignmentSource {
             .map_err(|source| FastxError::AlignmentReadError { source })?;
 
         let mut read_lengths: Vec<u32> = vec![];
-        let mut qname_to_idx: HashMap<Vec<u8>, usize> = HashMap::new();
+        let mut indexer = TemplateIndexer::default();
 
         for result in reader.records(&header) {
             let record = result.map_err(|source| FastxError::AlignmentReadError { source })?;
@@ -77,20 +94,11 @@ impl RecordSource for AlignmentSource {
             }
 
             let rlen = record.sequence().len() as u32;
-
-            if flags.is_segmented() {
-                let name = record
-                    .name()
-                    .map(|n| (n.as_ref() as &[u8]).to_vec())
-                    .unwrap_or_default();
-                if let Some(&idx) = qname_to_idx.get(&name) {
-                    read_lengths[idx] += rlen;
-                } else {
-                    qname_to_idx.insert(name, read_lengths.len());
-                    read_lengths.push(rlen);
-                }
-            } else {
+            let idx = indexer.index_for(&*record, flags);
+            if idx == read_lengths.len() {
                 read_lengths.push(rlen);
+            } else {
+                read_lengths[idx] += rlen;
             }
         }
 
@@ -106,8 +114,7 @@ impl RecordSource for AlignmentSource {
             .read_header()
             .map_err(|source| FastxError::AlignmentReadError { source })?;
 
-        let mut count: usize = 0;
-        let mut qname_seen: HashSet<Vec<u8>> = HashSet::new();
+        let mut indexer = TemplateIndexer::default();
 
         for result in reader.records(&header) {
             let record = result.map_err(|source| FastxError::AlignmentReadError { source })?;
@@ -119,20 +126,12 @@ impl RecordSource for AlignmentSource {
                 return Err(FastxError::MappedReadDetected);
             }
 
-            if flags.is_segmented() {
-                let name = record
-                    .name()
-                    .map(|n| (n.as_ref() as &[u8]).to_vec())
-                    .unwrap_or_default();
-                if qname_seen.insert(name) {
-                    count += 1;
-                }
-            } else {
-                count += 1;
-            }
+            indexer.index_for(&*record, flags);
         }
 
-        Ok(count)
+        // indices are assigned sequentially in first-seen order, so the number of templates seen
+        // equals the count of indices handed out.
+        Ok(indexer.next_idx)
     }
 
     fn filter_reads_into(
@@ -140,8 +139,7 @@ impl RecordSource for AlignmentSource {
         reads_to_keep: &[bool],
         nb_reads_keep: usize,
         write_to: &mut dyn Write,
-        output_format: Option<Format>,
-        is_fasta: bool,
+        encoding: OutputEncoding,
     ) -> Result<usize, FastxError> {
         let mut reader = noodles_util::alignment::io::reader::Builder::default()
             .build_from_path(&self.path)
@@ -151,16 +149,15 @@ impl RecordSource for AlignmentSource {
             .read_header()
             .map_err(|source| FastxError::AlignmentReadError { source })?;
 
-        let mut read_idx: usize = 0;
         let mut total_len = 0;
         let mut written_templates: HashSet<usize> = HashSet::new();
-        let mut qname_to_idx: HashMap<Vec<u8>, usize> = HashMap::new();
+        let mut indexer = TemplateIndexer::default();
 
         // If the output format is an alignment format (SAM/BAM/CRAM), we write alignment records
-        if let Some(format) = output_format {
+        if let OutputEncoding::Alignment(format) = encoding {
             {
                 // add rasusa program command line to header
-                let (pg_id, pg_map) = self.program_entry(&header);
+                let (pg_id, pg_map) = program_entry(&header);
                 header.programs_mut().as_mut().insert(pg_id.into(), pg_map);
 
                 let mut writer = noodles_util::alignment::io::writer::Builder::default()
@@ -178,25 +175,7 @@ impl RecordSource for AlignmentSource {
                     let flags = record
                         .flags()
                         .unwrap_or(noodles::sam::alignment::record::Flags::empty());
-
-                    let current_idx = if flags.is_segmented() {
-                        let name = record
-                            .name()
-                            .map(|n| (n.as_ref() as &[u8]).to_vec())
-                            .unwrap_or_default();
-                        if let Some(&idx) = qname_to_idx.get(&name) {
-                            idx
-                        } else {
-                            let idx = read_idx;
-                            qname_to_idx.insert(name, idx);
-                            read_idx += 1;
-                            idx
-                        }
-                    } else {
-                        let idx = read_idx;
-                        read_idx += 1;
-                        idx
-                    };
+                    let current_idx = indexer.index_for(&*record, flags);
 
                     if current_idx < reads_to_keep.len() && reads_to_keep[current_idx] {
                         total_len += record.sequence().len();
@@ -214,31 +193,14 @@ impl RecordSource for AlignmentSource {
                 source: anyhow::Error::from(source),
             })?;
         } else {
+            let is_fasta = matches!(encoding, OutputEncoding::Fastx { fasta: true });
             // Otherwise, we output as FASTQ (or FASTA)
             for result in reader.records(&header) {
                 let record = result.map_err(|source| FastxError::AlignmentReadError { source })?;
                 let flags = record
                     .flags()
                     .unwrap_or(noodles::sam::alignment::record::Flags::empty());
-
-                let current_idx = if flags.is_segmented() {
-                    let name = record
-                        .name()
-                        .map(|n| (n.as_ref() as &[u8]).to_vec())
-                        .unwrap_or_default();
-                    if let Some(&idx) = qname_to_idx.get(&name) {
-                        idx
-                    } else {
-                        let idx = read_idx;
-                        qname_to_idx.insert(name, idx);
-                        read_idx += 1;
-                        idx
-                    }
-                } else {
-                    let idx = read_idx;
-                    read_idx += 1;
-                    idx
-                };
+                let current_idx = indexer.index_for(&*record, flags);
 
                 if current_idx < reads_to_keep.len() && reads_to_keep[current_idx] {
                     total_len += record.sequence().len();
@@ -443,8 +405,7 @@ mod tests {
             &reads_to_keep,
             nb_reads_keep,
             &mut buffer,
-            Some(Format::Bam),
-            false,
+            OutputEncoding::Alignment(Format::Bam),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 10);
@@ -474,8 +435,12 @@ mod tests {
         let nb_reads_keep = 1;
         let mut buffer = Vec::new();
 
-        let result =
-            source.filter_reads_into(&reads_to_keep, nb_reads_keep, &mut buffer, None, true);
+        let result = source.filter_reads_into(
+            &reads_to_keep,
+            nb_reads_keep,
+            &mut buffer,
+            OutputEncoding::Fastx { fasta: true },
+        );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 10);
 
@@ -496,8 +461,12 @@ mod tests {
         let nb_reads_keep = 1;
         let mut buffer = Vec::new();
 
-        let result =
-            source.filter_reads_into(&reads_to_keep, nb_reads_keep, &mut buffer, None, false);
+        let result = source.filter_reads_into(
+            &reads_to_keep,
+            nb_reads_keep,
+            &mut buffer,
+            OutputEncoding::Fastx { fasta: false },
+        );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 10);
 
@@ -525,8 +494,7 @@ mod tests {
             &reads_to_keep,
             nb_reads_keep,
             &mut buffer,
-            Some(Format::Sam),
-            false,
+            OutputEncoding::Alignment(Format::Sam),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 20);
@@ -557,7 +525,12 @@ mod tests {
             let source = AlignmentSource::new(&sam_path);
             let mut bam_file = File::create(&bam_path).unwrap();
             source
-                .filter_reads_into(&[true, true], 2, &mut bam_file, Some(Format::Bam), false)
+                .filter_reads_into(
+                    &[true, true],
+                    2,
+                    &mut bam_file,
+                    OutputEncoding::Alignment(Format::Bam),
+                )
                 .unwrap();
         }
 
@@ -570,8 +543,7 @@ mod tests {
             &reads_to_keep,
             nb_reads_keep,
             &mut buffer,
-            Some(Format::Sam),
-            false,
+            OutputEncoding::Alignment(Format::Sam),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 10);


### PR DESCRIPTION
## Summary
- Adds `src/format.rs` as the single source of truth for extension→format detection (SAM/BAM/CRAM), extension→compression detection, compression-level defaults, and the CLI `OutputFormat`→noodles `Format` mapping — each of these was previously duplicated 2-3x across `reads.rs`, `fastx.rs`, `alignment/io.rs`, and `cli.rs`.
- Consolidates the duplicated `program_entry` (identical in `source.rs`'s `AlignmentSource` and `alignment/header.rs`'s `Alignment`) into one free function in `alignment/header.rs`.
- Extracts a `TemplateIndexer` helper in `source.rs` to de-duplicate the segmented-read (paired) qname-based indexing logic that was repeated across `read_lengths`, `count`, and both branches of `filter_reads_into`.
- Replaces `RecordSource::filter_reads_into`'s `(Option<Format>, bool is_fasta)` parameter pair with a single `OutputEncoding` enum, so `Fastx`'s implementation no longer takes noodles' alignment `Format` type as a parameter for a case (alignment output) it never actually receives.

Output-preserving refactor - no behavior change. Part of #170 (S7).

Closes #177

## Test plan
- [x] `cargo build --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --all-targets` (170 lib tests incl. new `format.rs`/`TemplateIndexer` coverage, all integration tests, both reproducibility tests) - all green
- [x] `cargo test --doc`
- [x] Grepped to confirm each consolidated helper (`infer_format_from_path`, `infer_format_from_char`, `infer_compression_format`, `default_compression_level`, `output_alignment_format`, `program_entry`) now has exactly one definition