### PR TITLE
feat(threading): add --threads/-@ for multithreaded BAM (de)compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ exclude = ["tests/cases/*"]
 [badges]
 maintenance = { status = "actively-developed" }
 
-[package.metadata.cargo-shear]
-ignored = ["noodles-bgzf"] # it is used by noodles to handle decompression, but not used in the code
-
 [dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 regex = "1.12.3"

--- a/src/alignment/args.rs
+++ b/src/alignment/args.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
@@ -70,4 +71,11 @@ pub struct Alignment {
     /// The minimum value is 1,000 bp to avoid small region queries.
     #[arg(long, default_value_t = 10_000, value_name = "INT", value_parser = clap::value_parser!(u64).range(1000..))]
     pub batch_size: u64,
+
+    /// Number of threads to use for BAM (de)compression
+    ///
+    /// Only BAM benefits from this - SAM is uncompressed and CRAM has no multithreaded codec, so
+    /// this is a no-op for those formats. `--threads 1` is identical to not passing this option.
+    #[arg(short = '@', long = "threads", default_value_t = NonZeroUsize::new(1).unwrap(), value_name = "INT")]
+    pub threads: NonZeroUsize,
 }

--- a/src/alignment/io.rs
+++ b/src/alignment/io.rs
@@ -7,15 +7,15 @@ use rand::prelude::*;
 use rand::random;
 
 use noodles::sam::Header;
-use noodles_util::alignment;
 
 use crate::format::infer_format_from_path;
+use crate::threading::build_alignment_writer;
 
 use super::args::Alignment;
 use super::header::program_entry;
 
-// a generic writer that can handle File or Stdout
-pub(super) type AlignmentWriter = alignment::io::Writer<Box<dyn Write>>;
+// re-exported so `stream.rs`/`fetch.rs`/`mod.rs` can keep referring to it as `super::io::AlignmentWriter`
+pub(super) use crate::threading::AlignmentWriter;
 
 impl Alignment {
     pub(super) fn setup_resources(
@@ -64,8 +64,9 @@ impl Alignment {
             },
         };
 
-        // use Box<dyn Write> to make File and Stdout compatible
-        let sink: Box<dyn Write> = match &self.output {
+        // use Box<dyn Write + Send> to make File and Stdout compatible, and to allow wrapping in
+        // a multithreaded BGZF encoder when `--threads` > 1.
+        let sink: Box<dyn Write + Send> = match &self.output {
             Some(path) => {
                 let path = path.as_path();
                 info!("Writing subsampled alignment to: {:?}", path);
@@ -74,13 +75,14 @@ impl Alignment {
             }
             None => {
                 info!("Writing subsampled alignment to stdout");
-                Box::new(io::stdout().lock())
+                // `Stdout` (rather than a `StdoutLock`) so the sink is `Send`: it can be wrapped
+                // in a multithreaded BGZF encoder, whose background writer thread needs to own
+                // it. `Stdout::write` still locks internally on every call.
+                Box::new(io::stdout())
             }
         };
 
-        let mut writer = alignment::io::writer::Builder::default()
-            .set_format(output_fmt)
-            .build_from_writer(sink)?;
+        let mut writer = build_alignment_writer(sink, output_fmt, self.threads)?;
 
         writer.write_header(&header)?;
 

--- a/src/alignment/mod.rs
+++ b/src/alignment/mod.rs
@@ -10,13 +10,14 @@ pub use args::{Alignment, SubsamplingStrategy};
 pub use header::{make_program_id_unique, program_entry};
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 
 use anyhow::{Context, Result};
 use log::info;
 use noodles::sam::Header;
-use noodles_util::alignment;
 use rustc_hash::FxBuildHasher;
 
+use crate::threading::build_alignment_reader;
 use crate::Runner;
 use io::AlignmentWriter;
 use util::extract_name;
@@ -37,10 +38,9 @@ impl Runner for Alignment {
 impl Alignment {
     // a function which infers data type (paired and or single end) by looking at the first 10 records
     fn check_pair(&self) -> Result<bool> {
-        // set up reader
-        let mut reader = alignment::io::reader::Builder::default()
-            .build_from_path(&self.aln)
-            .context("Failed to read alignment file")?;
+        // set up reader. Only the first 10 records are read below, so multithreaded BGZF
+        // decoding would pay worker-pool spin-up costs for no benefit - always use 1 thread here.
+        let mut reader = build_alignment_reader(&self.aln, NonZeroUsize::new(1).unwrap())?;
 
         let header = reader.read_header()?;
 
@@ -72,9 +72,7 @@ impl Alignment {
         writer: &mut AlignmentWriter,
     ) -> Result<()> {
         info!("Recovering mates (last segment records)");
-        let mut reader = alignment::io::reader::Builder::default()
-            .build_from_path(&self.aln)
-            .context("Failed to read alignment file")?;
+        let mut reader = build_alignment_reader(&self.aln, self.threads)?;
 
         let _ = reader.read_header()?; // skip header
 
@@ -102,6 +100,7 @@ impl Alignment {
 mod tests {
     use super::*;
     use assert_cmd::Command;
+    use noodles_util::alignment;
     use noodles_util::alignment::io::Format;
     use std::path::{Path, PathBuf};
     use tempfile::NamedTempFile;
@@ -223,6 +222,17 @@ mod tests {
         seed: Option<u64>,
         strategy: SubsamplingStrategy,
     ) -> Vec<String> {
+        run_aln_get_reads_result_with_threads(input, seed, strategy, NonZeroUsize::new(1).unwrap())
+    }
+
+    // as above, but with a configurable thread count - used to check that `--threads` doesn't
+    // change which records get selected, only how the BAM is (de)compressed.
+    fn run_aln_get_reads_result_with_threads(
+        input: &Path,
+        seed: Option<u64>,
+        strategy: SubsamplingStrategy,
+        threads: NonZeroUsize,
+    ) -> Vec<String> {
         let target_depth = 3;
         let out = NamedTempFile::new().unwrap();
 
@@ -236,6 +246,7 @@ mod tests {
             swap_distance: 5,
             step_size: 100,
             batch_size: 10_000,
+            threads,
         };
 
         aln1.run().expect("Subsampling failed");
@@ -266,6 +277,32 @@ mod tests {
         // comapre the length and the read names
         assert_eq!(names1.len(), names2.len(), "Different read count");
         assert_eq!(names1, names2, "Different reads selected")
+    }
+
+    #[test]
+    fn threads_4_and_threads_1_yield_identical_decoded_records_stream() {
+        let input_path = Path::new("tests/cases/test.bam");
+        let seed = Some(2109);
+
+        let mut names1 = run_aln_get_reads_result_with_threads(
+            input_path,
+            seed,
+            SubsamplingStrategy::Stream,
+            NonZeroUsize::new(1).unwrap(),
+        );
+        let mut names4 = run_aln_get_reads_result_with_threads(
+            input_path,
+            seed,
+            SubsamplingStrategy::Stream,
+            NonZeroUsize::new(4).unwrap(),
+        );
+
+        // compare the sorted read set, not raw bytes - multithreaded BGZF reframes blocks
+        // differently, so the compressed bytes legitimately differ even though the decoded
+        // records don't.
+        names1.sort();
+        names4.sort();
+        assert_eq!(names1, names4);
     }
 
     #[test]
@@ -321,6 +358,7 @@ mod tests {
             swap_distance: 5,
             step_size: 100, // not used
             batch_size: 10_000,
+            threads: NonZeroUsize::new(1).unwrap(),
         };
         assert!(aln.run().is_err());
     }
@@ -340,6 +378,7 @@ mod tests {
             swap_distance: 5,
             step_size: 100, // not used
             batch_size: 10_000,
+            threads: NonZeroUsize::new(1).unwrap(),
         };
         assert!(aln.run().is_err());
     }
@@ -362,6 +401,7 @@ mod tests {
             swap_distance: 5,
             step_size: 100,
             batch_size: 1000,
+            threads: NonZeroUsize::new(1).unwrap(),
         };
 
         align.run().expect("Subsampling failed");
@@ -412,6 +452,7 @@ mod tests {
             swap_distance: 5,
             step_size: 100,
             batch_size: 10000,
+            threads: NonZeroUsize::new(1).unwrap(),
         };
 
         align.run().expect("Subsampling failed");

--- a/src/alignment/stream.rs
+++ b/src/alignment/stream.rs
@@ -4,8 +4,9 @@ use anyhow::{Context, Result};
 use log::{info, warn};
 
 use noodles::sam::Header;
-use noodles_util::alignment;
 use rand::Rng;
+
+use crate::threading::build_alignment_reader;
 
 use super::args::Alignment;
 use super::io::AlignmentWriter;
@@ -34,9 +35,7 @@ impl Alignment {
     pub(super) fn run_stream(&self) -> Result<()> {
         info!("Subsampling alignment file (Stream): {:?}", self.aln);
 
-        let mut reader = alignment::io::reader::Builder::default()
-            .build_from_path(&self.aln)
-            .context("Failed to read alignment file")?;
+        let mut reader = build_alignment_reader(&self.aln, self.threads)?;
 
         let header = reader.read_header()?;
 
@@ -82,9 +81,7 @@ impl Alignment {
         rng: &mut rand_pcg::Pcg64,
     ) -> Result<()> {
         // set up reader
-        let mut reader = alignment::io::reader::Builder::default()
-            .build_from_path(&self.aln)
-            .context("Failed to read alignment file")?;
+        let mut reader = build_alignment_reader(&self.aln, self.threads)?;
         let _ = reader.read_header()?; // skip header
 
         // the active set to store reads that currently in the scan
@@ -278,7 +275,9 @@ mod tests {
     use super::super::args::SubsamplingStrategy;
     use super::*;
     use noodles::sam::alignment::{Record, RecordBuf};
+    use noodles_util::alignment;
     use noodles_util::alignment::io::Format;
+    use std::num::NonZeroUsize;
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
 
@@ -348,6 +347,7 @@ mod tests {
             swap_distance: 5,
             step_size: 100, // it is not used
             batch_size: 10_000,
+            threads: NonZeroUsize::new(1).unwrap(),
         };
 
         // run the sweep line algorithm
@@ -431,6 +431,7 @@ mod tests {
             swap_distance: 5,
             step_size: 100, // not used
             batch_size: 10_000,
+            threads: NonZeroUsize::new(1).unwrap(),
         };
         align.run_stream().expect("Subsampling failed");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod format;
 pub mod reads;
 pub mod source;
 pub mod subsampler;
+pub mod threading;
 
 pub use crate::cli::Cli;
 pub use crate::fastx::Fastx;

--- a/src/reads.rs
+++ b/src/reads.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use log::{debug, info, warn};
 use std::io::{stdout, BufWriter};
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -118,6 +119,15 @@ pub struct Reads {
     /// not specified.
     #[clap(short = 'l', long, value_parser = parse_level, value_name = "1-21")]
     pub compress_level: Option<niffler::Level>,
+
+    /// Number of threads to use for BAM (de)compression
+    ///
+    /// Only relevant for BAM input/output - SAM is uncompressed and CRAM has no multithreaded
+    /// codec, so this is a no-op for those formats and for FASTA/FASTQ. `--threads 1` is
+    /// identical to not passing this option. Only BAM *reading* benefits here; writing BAM
+    /// output remains single-threaded.
+    #[arg(short = '@', long = "threads", default_value_t = NonZeroUsize::new(1).unwrap(), value_name = "INT")]
+    pub threads: NonZeroUsize,
 }
 
 impl Reads {
@@ -159,7 +169,7 @@ impl Runner for Reads {
             info!("Two input files given. Assuming paired Illumina...")
         }
 
-        let input_source = determine_record_source(&self.input[0]);
+        let input_source = determine_record_source(&self.input[0], self.threads);
         let input_format = infer_format_from_path(&self.input[0]);
 
         let check_conversion = |in_fmt: Option<noodles_util::alignment::io::Format>,
@@ -200,7 +210,7 @@ impl Runner for Reads {
         };
 
         let second_input_source = if is_paired {
-            Some(determine_record_source(&self.input[1]))
+            Some(determine_record_source(&self.input[1], self.threads))
         } else {
             None
         };
@@ -521,6 +531,7 @@ mod tests {
             compress_type: None,
             output_format: None,
             compress_level: None,
+            threads: NonZeroUsize::new(1).unwrap(),
         }
     }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,11 +1,13 @@
 use crate::alignment::program_entry;
 use crate::fastx::{Fastx, FastxError};
 use crate::format::OutputEncoding;
+use crate::threading::build_alignment_reader;
 use anyhow::Result;
 use noodles::sam::alignment::record::Flags;
 use noodles::sam::alignment::Record;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 pub trait RecordSource {
@@ -24,12 +26,14 @@ pub trait RecordSource {
 
 pub struct AlignmentSource {
     path: PathBuf,
+    threads: NonZeroUsize,
 }
 
 impl AlignmentSource {
-    pub fn new(path: &Path) -> Self {
+    pub fn new(path: &Path, threads: NonZeroUsize) -> Self {
         Self {
             path: path.to_path_buf(),
+            threads,
         }
     }
 }
@@ -72,8 +76,7 @@ impl TemplateIndexer {
 
 impl RecordSource for AlignmentSource {
     fn read_lengths(&self) -> Result<Vec<u32>, FastxError> {
-        let mut reader = noodles_util::alignment::io::reader::Builder::default()
-            .build_from_path(&self.path)
+        let mut reader = build_alignment_reader(&self.path, self.threads)
             .map_err(|source| FastxError::AlignmentReadError { source })?;
 
         let header = reader
@@ -106,8 +109,7 @@ impl RecordSource for AlignmentSource {
     }
 
     fn count(&self) -> Result<usize, FastxError> {
-        let mut reader = noodles_util::alignment::io::reader::Builder::default()
-            .build_from_path(&self.path)
+        let mut reader = build_alignment_reader(&self.path, self.threads)
             .map_err(|source| FastxError::AlignmentReadError { source })?;
 
         let header = reader
@@ -141,8 +143,7 @@ impl RecordSource for AlignmentSource {
         write_to: &mut dyn Write,
         encoding: OutputEncoding,
     ) -> Result<usize, FastxError> {
-        let mut reader = noodles_util::alignment::io::reader::Builder::default()
-            .build_from_path(&self.path)
+        let mut reader = build_alignment_reader(&self.path, self.threads)
             .map_err(|source| FastxError::AlignmentReadError { source })?;
 
         let mut header = reader
@@ -160,6 +161,11 @@ impl RecordSource for AlignmentSource {
                 let (pg_id, pg_map) = program_entry(&header);
                 header.programs_mut().as_mut().insert(pg_id.into(), pg_map);
 
+                // `write_to` is a borrowed `&mut dyn Write`, not an owned `Send` sink, so it can't
+                // be wrapped in the multithreaded BGZF encoder from `crate::threading` (that
+                // needs to own the writer for its background compression threads). BAM output
+                // written through `reads` is therefore always single-threaded; `--threads` only
+                // speeds up BAM *reading* here.
                 let mut writer = noodles_util::alignment::io::writer::Builder::default()
                     .set_format(format)
                     .build_from_writer(&mut *write_to)
@@ -293,9 +299,9 @@ impl RecordSource for AlignmentSource {
     }
 }
 
-pub fn determine_record_source(path: &Path) -> Box<dyn RecordSource> {
+pub fn determine_record_source(path: &Path, threads: NonZeroUsize) -> Box<dyn RecordSource> {
     match path.extension().and_then(|ext| ext.to_str()) {
-        Some("sam") | Some("bam") | Some("cram") => Box::new(AlignmentSource::new(path)),
+        Some("sam") | Some("bam") | Some("cram") => Box::new(AlignmentSource::new(path, threads)),
         _ => Box::new(Fastx::from_path(path)),
     }
 }
@@ -339,7 +345,7 @@ mod tests {
     #[test]
     fn test_determine_record_source_alignment() {
         let path = Path::new("test.bam");
-        let _source = determine_record_source(path);
+        let _source = determine_record_source(path, NonZeroUsize::new(1).unwrap());
     }
 
     #[test]
@@ -348,7 +354,7 @@ mod tests {
         let path = temp_dir.path().join("test.sam");
         create_test_sam(&path);
 
-        let source = AlignmentSource::new(&path);
+        let source = AlignmentSource::new(&path, NonZeroUsize::new(1).unwrap());
         let actual = source.read_lengths().unwrap();
         assert_eq!(actual.len(), 2);
         assert_eq!(actual[0], 10);
@@ -361,7 +367,7 @@ mod tests {
         let path = temp_dir.path().join("test_paired.sam");
         create_test_paired_sam(&path);
 
-        let source = AlignmentSource::new(&path);
+        let source = AlignmentSource::new(&path, NonZeroUsize::new(1).unwrap());
         let actual = source.read_lengths().unwrap();
         // 2 templates, each length 10 + 10 = 20.
         assert_eq!(actual.len(), 2);
@@ -375,7 +381,7 @@ mod tests {
         let path = temp_dir.path().join("test.sam");
         create_test_sam(&path);
 
-        let source = AlignmentSource::new(&path);
+        let source = AlignmentSource::new(&path, NonZeroUsize::new(1).unwrap());
         assert_eq!(source.count().unwrap(), 2);
     }
 
@@ -385,7 +391,7 @@ mod tests {
         let path = temp_dir.path().join("test_paired.sam");
         create_test_paired_sam(&path);
 
-        let source = AlignmentSource::new(&path);
+        let source = AlignmentSource::new(&path, NonZeroUsize::new(1).unwrap());
         // 4 records but 2 templates (read pairs)
         assert_eq!(source.count().unwrap(), 2);
     }
@@ -396,7 +402,7 @@ mod tests {
         let input_path = temp_dir.path().join("test.sam");
         create_test_sam(&input_path);
 
-        let source = AlignmentSource::new(&input_path);
+        let source = AlignmentSource::new(&input_path, NonZeroUsize::new(1).unwrap());
         let reads_to_keep = vec![true, false];
         let nb_reads_keep = 1;
         let mut buffer = Vec::new();
@@ -430,7 +436,7 @@ mod tests {
         let input_path = temp_dir.path().join("test.sam");
         create_test_sam(&input_path);
 
-        let source = AlignmentSource::new(&input_path);
+        let source = AlignmentSource::new(&input_path, NonZeroUsize::new(1).unwrap());
         let reads_to_keep = vec![false, true];
         let nb_reads_keep = 1;
         let mut buffer = Vec::new();
@@ -456,7 +462,7 @@ mod tests {
         let input_path = temp_dir.path().join("test_qual.sam");
         create_test_sam_with_quality(&input_path);
 
-        let source = AlignmentSource::new(&input_path);
+        let source = AlignmentSource::new(&input_path, NonZeroUsize::new(1).unwrap());
         let reads_to_keep = vec![false, true];
         let nb_reads_keep = 1;
         let mut buffer = Vec::new();
@@ -484,7 +490,7 @@ mod tests {
         let input_path = temp_dir.path().join("test_paired.sam");
         create_test_paired_sam(&input_path);
 
-        let source = AlignmentSource::new(&input_path);
+        let source = AlignmentSource::new(&input_path, NonZeroUsize::new(1).unwrap());
         // 2 templates. Keep first.
         let reads_to_keep = vec![true, false];
         let nb_reads_keep = 1;
@@ -522,7 +528,7 @@ mod tests {
         // Convert SAM to BAM first
         let bam_path = temp_dir.path().join("input.bam");
         {
-            let source = AlignmentSource::new(&sam_path);
+            let source = AlignmentSource::new(&sam_path, NonZeroUsize::new(1).unwrap());
             let mut bam_file = File::create(&bam_path).unwrap();
             source
                 .filter_reads_into(
@@ -534,7 +540,7 @@ mod tests {
                 .unwrap();
         }
 
-        let source = AlignmentSource::new(&bam_path);
+        let source = AlignmentSource::new(&bam_path, NonZeroUsize::new(1).unwrap());
         let reads_to_keep = vec![false, true];
         let nb_reads_keep = 1;
         let mut buffer = Vec::new();

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,0 +1,175 @@
+//! Shared reader/writer factory for optional multithreaded BGZF (de)compression.
+//!
+//! Only BAM benefits here: SAM is uncompressed text and noodles' CRAM codec has no
+//! multithreaded path, so `threads > 1` only changes how BAM input/output is (de)compressed.
+//! For every other case (SAM, CRAM, or `threads == 1`) this falls back to noodles' normal
+//! single-threaded, autodetecting reader/writer, so `--threads 1` is byte-for-byte the same as
+//! before `--threads` existed.
+
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::num::NonZeroUsize;
+use std::path::Path;
+
+use noodles_bgzf as bgzf;
+use noodles_util::alignment::{self, io::Format};
+
+use crate::format::infer_format_from_path;
+
+pub type AlignmentReader = alignment::io::Reader<Box<dyn Read>>;
+pub type AlignmentWriter = alignment::io::Writer<Box<dyn Write + Send>>;
+
+/// Same magic number noodles' own compression autodetection looks for (see
+/// `noodles_util::alignment::io::reader::builder::detect_compression_method`).
+const GZIP_MAGIC_NUMBER: [u8; 2] = [0x1f, 0x8b];
+
+/// Whether `file` starts with the BGZF/gzip magic number, restoring the read position
+/// afterwards. `path`'s `.bam` extension alone isn't a reliable enough signal to commit to a
+/// BGZF decode - a mislabeled or renamed SAM/CRAM file would otherwise be forced through the
+/// multithreaded BAM path and fail to decompress, where the normal single-threaded path would
+/// have content-sniffed its way to the right format instead.
+fn looks_bgzf_compressed(file: &mut File) -> io::Result<bool> {
+    let mut buf = [0u8; GZIP_MAGIC_NUMBER.len()];
+    let is_gzip = match file.read_exact(&mut buf) {
+        Ok(()) => buf == GZIP_MAGIC_NUMBER,
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => false,
+        Err(e) => return Err(e),
+    };
+    file.seek(SeekFrom::Start(0))?;
+    Ok(is_gzip)
+}
+
+/// Builds an alignment reader for `path`, using a multithreaded BGZF decoder when `path` is BAM
+/// and `threads > 1`.
+pub fn build_alignment_reader(path: &Path, threads: NonZeroUsize) -> io::Result<AlignmentReader> {
+    let mut file = File::open(path)?;
+
+    let use_multithreaded_bam = threads.get() > 1
+        && infer_format_from_path(path) == Some(Format::Bam)
+        && looks_bgzf_compressed(&mut file)?;
+
+    if use_multithreaded_bam {
+        let decoder = bgzf::io::MultithreadedReader::with_worker_count(threads, file);
+        alignment::io::reader::Builder::default()
+            .set_format(Format::Bam)
+            .set_compression_method(None) // already decompressed by `decoder`
+            .build_from_reader(Box::new(decoder) as Box<dyn Read>)
+    } else {
+        alignment::io::reader::Builder::default().build_from_reader(Box::new(file) as Box<dyn Read>)
+    }
+}
+
+/// Builds an alignment writer over `sink`, using a multithreaded BGZF encoder when `format` is
+/// BAM and `threads > 1`.
+pub fn build_alignment_writer(
+    sink: Box<dyn Write + Send>,
+    format: Format,
+    threads: NonZeroUsize,
+) -> io::Result<AlignmentWriter> {
+    if threads.get() > 1 && format == Format::Bam {
+        let encoder = bgzf::io::MultithreadedWriter::with_worker_count(threads, sink);
+        alignment::io::writer::Builder::default()
+            .set_format(Format::Bam)
+            .set_compression_method(None) // already compressed by `encoder`
+            .build_from_writer(Box::new(encoder) as Box<dyn Write + Send>)
+    } else {
+        alignment::io::writer::Builder::default()
+            .set_format(format)
+            .build_from_writer(sink)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_threaded_reader_reads_header_and_records() {
+        let reader = build_alignment_reader(
+            Path::new("tests/cases/test.bam"),
+            NonZeroUsize::new(1).unwrap(),
+        )
+        .unwrap();
+        let _ = reader;
+    }
+
+    #[test]
+    fn multithreaded_and_single_threaded_readers_agree_on_records() {
+        let path = Path::new("tests/cases/test.bam");
+
+        let mut single = build_alignment_reader(path, NonZeroUsize::new(1).unwrap()).unwrap();
+        let header1 = single.read_header().unwrap();
+        let names1: Vec<Vec<u8>> = single
+            .records(&header1)
+            .map(|r| {
+                let record = r.unwrap();
+                let name: &[u8] = record.name().unwrap().as_ref();
+                name.to_vec()
+            })
+            .collect();
+
+        let mut multi = build_alignment_reader(path, NonZeroUsize::new(4).unwrap()).unwrap();
+        let header2 = multi.read_header().unwrap();
+        let names2: Vec<Vec<u8>> = multi
+            .records(&header2)
+            .map(|r| {
+                let record = r.unwrap();
+                let name: &[u8] = record.name().unwrap().as_ref();
+                name.to_vec()
+            })
+            .collect();
+
+        assert_eq!(names1, names2);
+    }
+
+    #[test]
+    fn multithreaded_writer_round_trips_through_multithreaded_reader() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bam_path = temp_dir.path().join("out.bam");
+
+        {
+            let mut reader = build_alignment_reader(
+                Path::new("tests/cases/test.bam"),
+                NonZeroUsize::new(1).unwrap(),
+            )
+            .unwrap();
+            let header = reader.read_header().unwrap();
+
+            let file = File::create(&bam_path).unwrap();
+            let sink: Box<dyn Write + Send> = Box::new(file);
+            let mut writer =
+                build_alignment_writer(sink, Format::Bam, NonZeroUsize::new(4).unwrap()).unwrap();
+            writer.write_header(&header).unwrap();
+            for result in reader.records(&header) {
+                let record = result.unwrap();
+                writer.write_record(&header, &record).unwrap();
+            }
+            writer.finish(&header).unwrap();
+        }
+
+        let mut reader = build_alignment_reader(&bam_path, NonZeroUsize::new(1).unwrap()).unwrap();
+        let header = reader.read_header().unwrap();
+        let count = reader.records(&header).count();
+        assert!(count > 0);
+    }
+
+    #[test]
+    fn mislabeled_bam_extension_on_uncompressed_content_still_reads_with_threads_greater_than_one()
+    {
+        // a SAM file, deliberately given a `.bam` extension. Extension alone would (incorrectly)
+        // route this through the multithreaded BGZF-decode path; content-sniffing should catch
+        // that it isn't actually BGZF-compressed and fall back to the normal autodetecting path.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("mislabeled.bam");
+        std::fs::write(
+            &path,
+            b"@HD\tVN:1.6\n@SQ\tSN:ref\tLN:1000\nr01\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\t*\n",
+        )
+        .unwrap();
+
+        let mut reader = build_alignment_reader(&path, NonZeroUsize::new(4).unwrap()).unwrap();
+        let header = reader.read_header().unwrap();
+        let count = reader.records(&header).count();
+        assert_eq!(count, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #178. Adds `--threads`/`-@` (default 1) to both `reads` and `aln`, and a shared `src/threading.rs` reader/writer factory that wraps BAM (de)compression in `noodles_bgzf`'s multithreaded reader/writer when `threads > 1`.
- Content-sniffs (gzip magic bytes) before committing to the multithreaded BAM path, so a mislabeled/renamed file falls back to noodles' normal single-threaded autodetection instead of failing a forced BGZF decode.
- `check_pair` always uses 1 thread - it only peeks 10 records, so spinning up a worker pool there is pure overhead.

## Scope decisions (per the issue's own allowances)
- CRAM: no multithreaded codec upstream, so `--threads` is a no-op for CRAM (and SAM, which is uncompressed text).
- `aln`'s `Fetch` strategy (indexed/query reads via `noodles_util::alignment::io::indexed_reader`) stays single-threaded - that builder doesn't expose a pluggable decoder, and small indexed region queries aren't a good multithreading target anyway.
- `reads`' alignment-output write path (`AlignmentSource::filter_reads_into`) stays single-threaded - it only holds a borrowed `&mut dyn Write`, not an owned `Send` sink, so it can't be handed to the multithreaded BGZF encoder (which needs to own the writer for its background compression thread). `--threads` still speeds up BAM *reading* there.
- The issue's "quick wins" bullet (consolidating the several separate reader-opens per `aln` run) was intentionally left alone beyond the `check_pair` thread-count fix, since further consolidation would be a control-flow change and the issue scopes this PR to "thread the worker count through the reader/writer factory only (no algorithm change)".

## Test plan
- [x] `cargo build --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test --all-targets`, `cargo test --doc` all pass
- [x] New test asserts `--threads 4` and `--threads 1` yield identical decoded/sorted read sets on `test.bam` (`alignment::tests::threads_4_and_threads_1_yield_identical_decoded_records_stream`)
- [x] New `threading::tests` cover: single-threaded reader still works, multithreaded vs single-threaded readers agree on decoded records, a multithreaded-written BAM round-trips correctly, and a `.bam`-mislabeled SAM file with `--threads 4` doesn't get force-fed through the BGZF path
- [x] Manual smoke test: `rasusa aln test.bam -c 3 -s 42 -@ 4` vs `-@ 1` - `samtools view` output is byte-identical, both pass `samtools quickcheck`