### PR TITLE
ci: post benchmark PR comparison as a sticky PR comment

### DIFF
--- a/.github/workflows/benchmark-pr.yaml
+++ b/.github/workflows/benchmark-pr.yaml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -53,7 +57,7 @@ jobs:
         continue-on-error: true
         run: benches/bench.sh compare origin/main | tee bench-compare.txt
 
-      - name: Add comparison to job summary
+      - name: Render comparison markdown
         if: always()
         env:
           README_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/benches/README.md
@@ -66,4 +70,11 @@ jobs:
             echo '```'
             cat bench-compare.txt 2>/dev/null || echo "(no output captured)"
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee bench-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post comparison as PR comment
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: benchmark-comparison
+          path: bench-comment.md


### PR DESCRIPTION
## Summary
- The `Benchmark PR` workflow's wall-time/peak-RSS comparison vs `main` was only written to the job summary, which is easy to miss on a PR.
- Added a step using `marocchino/sticky-pull-request-comment` to also post it as a PR comment, updated in place (via a sticky `header`) on every push so reruns don't spam new comments.
- Added `pull-requests: write` permission (required to post/update the comment); kept `contents: read`.

Note: sticky-pull-request-comment relies on the workflow's `GITHUB_TOKEN`, which GitHub restricts to read-only for `pull_request` events from forks - the comment will only post for PRs from branches in this repo, same as before for anything requiring write access. Same-repo PRs (which is the norm here) work fine.

## Test plan
- [x] YAML validated
- [ ] Confirm the comment appears on this PR once the `Benchmark PR` workflow runs