### PR TITLE
chore: allow deps as a conventional commit type

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -8,6 +8,7 @@ pre_bump_hooks = [
 [commit_types]
 bench = { changelog_title = "Benchmarks", omit_from_changelog = false }
 chore = { changelog_title = "Chores", omit_from_changelog = false }
+deps = { changelog_title = "Dependencies", omit_from_changelog = false }
 feat = { changelog_title = "Features", omit_from_changelog = false }
 fix = { changelog_title = "Bug Fixes", omit_from_changelog = false }
 perf = { changelog_title = "Performance Improvements", omit_from_changelog = false }


### PR DESCRIPTION
## Summary
Follow-up to #201 (merged, added `bench`). `.github/dependabot.yml` prefixes every cargo dependency bump with `deps` (`commit-message.prefix: "deps"`), producing commits like `deps(deps): bump regex from 1.12.3 to 1.13.1` - but `deps` wasn't in `cog.toml`'s allow-list, so every open dependabot cargo PR fails "check conventional commit compliance".

Adds `deps` to the allow-list, same pattern as `bench`.

## Test plan
- [x] `cog check --from-latest-tag` passes locally