### PR TITLE
chore(bench): re-baseline + document v5.0.0 performance (S11)

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -70,12 +70,12 @@ jobs:
         with:
           tool: hyperfine
 
-      - name: Install filtlong, seqtk, pyfastaq (bioconda)
+      - name: Install filtlong, seqtk (bioconda)
         if: steps.guard.outputs.skip != 'true'
         uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: bench-tools
-          create-args: -c bioconda -c conda-forge filtlong seqtk pyfastaq
+          create-args: -c bioconda -c conda-forge filtlong seqtk
           init-shell: bash
 
       - name: Regenerate README benchmark tables

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -70,12 +70,12 @@ jobs:
         with:
           tool: hyperfine
 
-      - name: Install filtlong, seqtk, fastaq (bioconda)
+      - name: Install filtlong, seqtk, pyfastaq (bioconda)
         if: steps.guard.outputs.skip != 'true'
         uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: bench-tools
-          create-args: -c bioconda -c conda-forge filtlong seqtk fastaq
+          create-args: -c bioconda -c conda-forge filtlong seqtk pyfastaq
           init-shell: bash
 
       - name: Regenerate README benchmark tables

--- a/README.md
+++ b/README.md
@@ -766,6 +766,36 @@ So, `rasusa reads` is faster than `seqtk` but doesn't require a fixed number of 
 allowing you to avoid doing maths to determine how many reads you need to downsample to
 a specific coverage. 🤓
 
+### v4.1.0 → v5.0.0 runtime/memory improvements
+
+<!-- INTERNAL-BENCH:START -->
+> [!NOTE]
+> This block is hand-written, not auto-regenerated - see [`benches/README.md`](benches/README.md)
+> if you want to reproduce these numbers yourself with `benches/bench.sh compare 4.1.0 5.0.0`.
+
+Between v4.1.0 and v5.0.0, `rasusa` went through a runtime/memory optimisation pass
+(tracked in [#170](https://github.com/mbhall88/rasusa/issues/170)). The internal
+benchmark harness (`benches/bench.sh`, distinct from the `filtlong`/`seqtk` comparisons
+above) shows the gains per scenario, comparing `bench.sh run` on the `4.1.0` and `5.0.0`
+tags:
+
+| Scenario                                    | Wall time |    Peak RSS | Notes                                            |
+|----------------------------------------------|----------:|------------:|---------------------------------------------------|
+| `reads` `--num`/`--frac` (1M reads, keep 25%) |     ~-8%  |   ~-31/-34% | O(k) selection ([#180](https://github.com/mbhall88/rasusa/issues/180)) |
+| `reads` `--num` (10M reads, keep 1,000)       |     ~-8%  |       ~-74% | same change, extreme n≫k case (54 MB → 14 MB)      |
+| `reads` paired `--num`                        |     ~-7%  |       ~-25% | O(k) selection applies to paired mode too         |
+| `reads` `--coverage`/`--bases`                |     ~-8%  |    unchanged | selection algorithm here is deliberately untouched |
+| `aln` (stream/fetch/paired)                   |  ~-16/-21% |      mixed  | from other S1-S9 work (buffered I/O, lighter alignment domain types); RSS deltas here are within measurement noise on these tiny test fixtures |
+
+The standout is `--num`/`--frac`'s peak memory: selection used to shuffle a full
+`n`-length index vector regardless of how few reads were being kept, so memory scaled
+with input size, not output size. It now scales with `k` (reads kept) instead - the
+gap widens the larger the input gets relative to what you're keeping, which is exactly
+the "downsample a huge run to a small target set" use case this tool exists for. See
+[PR #199](https://github.com/mbhall88/rasusa/pull/199) for the full investigation and a
+scaling chart across input sizes.
+<!-- INTERNAL-BENCH:END -->
+
 ## Contributing
 
 If you would like to help improve `rasusa` you are very welcome!

--- a/benches/baseline.json
+++ b/benches/baseline.json
@@ -1,42 +1,47 @@
 {
   "bench_reads": "1000000",
-  "commit": "3694f3453dba6b23692e97c46a58fc0e9db6c726",
-  "ref": "local",
+  "commit": "3031d5d17057541ede937f0ec0ca810c1a146798",
+  "ref": "5.0.0",
   "scenarios": {
     "aln-fetch": {
-      "peak_rss_bytes": 14630912,
-      "wall_mean_s": 1.3183261658199998,
-      "wall_stddev_s": 0.002899039941779387
+      "peak_rss_bytes": 12124160,
+      "wall_mean_s": 1.11276658588,
+      "wall_stddev_s": 0.003767073550685083
     },
     "aln-paired": {
-      "peak_rss_bytes": 8716288,
-      "wall_mean_s": 0.39462346236000007,
-      "wall_stddev_s": 0.0026262471740279058
+      "peak_rss_bytes": 9797632,
+      "wall_mean_s": 0.31002749754000003,
+      "wall_stddev_s": 0.005206021892146272
     },
     "aln-stream": {
-      "peak_rss_bytes": 6242304,
-      "wall_mean_s": 0.42111742828,
-      "wall_stddev_s": 0.001126413602565414
+      "peak_rss_bytes": 7192576,
+      "wall_mean_s": 0.33698788158,
+      "wall_stddev_s": 0.0026447172716985265
     },
     "reads-coverage": {
-      "peak_rss_bytes": 13058048,
-      "wall_mean_s": 0.17606008646000001,
-      "wall_stddev_s": 0.00451791483244252
+      "peak_rss_bytes": 13074432,
+      "wall_mean_s": 0.16123834278000002,
+      "wall_stddev_s": 0.002301069425936937
     },
     "reads-frac": {
-      "peak_rss_bytes": 11927552,
-      "wall_mean_s": 0.15787740088000002,
-      "wall_stddev_s": 0.0020511300034965936
+      "peak_rss_bytes": 7880704,
+      "wall_mean_s": 0.14482669842,
+      "wall_stddev_s": 0.0031613495743621615
     },
     "reads-num": {
-      "peak_rss_bytes": 13041664,
-      "wall_mean_s": 0.15763205008,
-      "wall_stddev_s": 0.0015971942069646179
+      "peak_rss_bytes": 9043968,
+      "wall_mean_s": 0.14479008182000003,
+      "wall_stddev_s": 0.0027578916161974643
+    },
+    "reads-num-sparse": {
+      "peak_rss_bytes": 14237696,
+      "wall_mean_s": 1.2290750233800003,
+      "wall_stddev_s": 0.005932661037527749
     },
     "reads-paired": {
-      "peak_rss_bytes": 6406144,
-      "wall_mean_s": 0.07188619854000002,
-      "wall_stddev_s": 0.0012933027312806583
+      "peak_rss_bytes": 4816896,
+      "wall_mean_s": 0.06654411666,
+      "wall_stddev_s": 0.0004903496396722113
     }
   }
 }

--- a/benches/update_readme.sh
+++ b/benches/update_readme.sh
@@ -6,9 +6,11 @@
 # them under data/download-cache/ (override with BENCH_DOWNLOAD_CACHE). Intended to run
 # from .github/workflows/benchmark.yaml on release; not routine local use.
 #
-# Requires on PATH: hyperfine, filtlong, seqtk, fastaq, wget, python3, cargo (unless
-# RASUSA_BIN is set to a prebuilt binary). filtlong/seqtk/fastaq are available via
-# bioconda: `conda install -c bioconda filtlong seqtk fastaq`.
+# Requires on PATH: hyperfine, filtlong, seqtk, wget, python3, cargo (unless
+# RASUSA_BIN is set to a prebuilt binary). filtlong/seqtk are available via bioconda:
+# `conda install -c bioconda filtlong seqtk`. The paired-end dataset is interleaved -
+# deinterleaving it is a one-off data-prep step, done with a plain awk split below
+# rather than pulling in a tool dependency for it (see the comment at that step for why).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,7 +30,6 @@ require() {
 require hyperfine
 require filtlong
 require seqtk
-require fastaq
 require wget
 require python3
 
@@ -75,7 +76,14 @@ R2_FQ="$CACHE_DIR/r2.fq"
 if [[ ! -f "$R1_FQ" || ! -f "$R2_FQ" ]]; then
     echo "[update_readme] downloading paired-end dataset..." >&2
     URL="ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR648/008/SRR6488968/SRR6488968.fastq.gz"
-    wget -q "$URL" -O - | gzip -d -c - | fastaq deinterleave - "$R1_FQ" "$R2_FQ"
+    # Deinterleave (alternating 4-line R1/R2 records) with awk rather than a tool
+    # dependency (e.g. pyfastaq's `fastaq deinterleave`) - this is a one-off data-prep
+    # step, not part of what's being benchmarked, so it doesn't need to match any
+    # particular tool's implementation.
+    wget -q "$URL" -O - | gzip -d -c - | awk -v r1="$R1_FQ" -v r2="$R2_FQ" '{
+        if (((NR - 1) % 8) < 4) print > r1
+        else print > r2
+    }'
 else
     echo "[update_readme] using cached $R1_FQ / $R2_FQ" >&2
 fi


### PR DESCRIPTION
## Summary
Closes #181 (S11 · Re-baseline + document performance), the final step of the runtime/memory optimisation epic (#170).

- Re-ran `benches/bench.sh run` on the actual `5.0.0` tag and refreshed `benches/baseline.json` (previously a stale 4.1.0 snapshot).
- Added a hand-written "v4.1.0 → v5.0.0" before/after summary to `README.md`, in its own `<!-- INTERNAL-BENCH:START/END -->` block, distinct from the auto-regenerated `filtlong`/`seqtk` comparison tables. Computed directly from the old and new `baseline.json` values (plus the n=10M/k=1000 scaling data point from PR #199's investigation).
- While verifying the README's auto-regen-on-release tables (S1B) had actually run, found `.github/workflows/benchmark.yaml` had **never succeeded** - its first-ever run (triggered by the 5.0.0 release) failed:
  - Bug 1: it installed a bioconda package named `fastaq`, which doesn't exist - the real package is `pyfastaq`.
  - Bug 2 (surfaced after fixing #1): `pyfastaq`'s own `fastaq deinterleave` CLI crashes with `NameError: name 'pyfastaq' is not defined` - a bug in `pyfastaq`'s own `app_fastaq.py` (an `exec()` call referencing `pyfastaq.runners.*` without that name ever being bound in its globals), not a Python-version issue.
  - Since that CLI call is just a one-off data-prep step (splitting one interleaved FASTQ into R1/R2, not part of what's being benchmarked), replaced it with a plain `awk` one-liner in `benches/update_readme.sh` instead of depending on a broken external tool.
- The optional "lightweight CI job running `bench.sh compare` on PRs" was already implemented in an earlier PR (`.github/workflows/benchmark-pr.yaml`) - not part of this diff.

**Verification gap**: `benchmark.yaml` hardcodes `ref: main` in its checkout step (by design - it commits results back to main), so it can't be fully exercised via `workflow_dispatch` on this feature branch pre-merge. I confirmed the fix's logic locally (awk deinterleave tested end-to-end through a real `gzip | awk` pipe with a synthetic interleaved FASTQ) and confirmed the `filtlong` comparison itself already works in CI (it succeeded in an earlier dispatch before hitting the `pyfastaq` bug). I'll re-trigger `workflow_dispatch` against `main` after this merges to give it a final confirming run.

## Test plan
- [x] `cargo build/test/clippy/fmt` all clean
- [x] `cog check --from-latest-tag` clean
- [x] `cargo shear` - no unused deps
- [x] awk deinterleave verified locally against a synthetic interleaved FASTQ (correct 4-line-record R1/R2 split) and through the real `gzip -d -c | awk` pipe
- [x] `filtlong` vs `rasusa` comparison confirmed working end-to-end in an actual CI run (56.83x faster) before the `pyfastaq` CLI bug was hit downstream
- [ ] Full `benchmark.yaml` success against `main` post-merge (will re-trigger and confirm)