### PR TITLE
fix(bench): correctly identify the rasusa command in README benchmark tables

### DIFF
--- a/benches/render_readme.py
+++ b/benches/render_readme.py
@@ -20,6 +20,17 @@ def _load_results(json_path):
         return json.load(f)["results"]
 
 
+# Matches the rasusa invocation specifically (executable named "rasusa" followed by a
+# subcommand), not just any command whose *arguments* happen to contain the substring
+# "rasusa" - which they always do in CI, since the repo (and so the checkout path,
+# e.g. /home/runner/work/rasusa/rasusa/...) is named "rasusa" too.
+_RASUSA_CMD_RE = re.compile(r"(?:^|/)rasusa (reads|aln)\b")
+
+
+def _is_rasusa_cmd(command):
+    return _RASUSA_CMD_RE.search(command) is not None
+
+
 def _read_table(md_path):
     with open(md_path) as f:
         return f.read().rstrip("\n")
@@ -28,7 +39,7 @@ def _read_table(md_path):
 def cmd_single_block(args):
     md_path, json_path = args
     results = _load_results(json_path)
-    rasusa = next(r for r in results if "rasusa" in r["command"])
+    rasusa = next(r for r in results if _is_rasusa_cmd(r["command"]))
     other = next(r for r in results if r is not rasusa)
 
     table = _read_table(md_path)
@@ -41,7 +52,7 @@ def cmd_single_block(args):
 def cmd_paired_block(args):
     md_path, json_path = args
     results = _load_results(json_path)
-    rasusa = next(r for r in results if "rasusa" in r["command"])
+    rasusa = next(r for r in results if _is_rasusa_cmd(r["command"]))
     others = [r for r in results if r is not rasusa]
     # Order: 1-pass seqtk, 2-pass seqtk, matching the hyperfine invocation order.
     ratio1 = _relative_str(others[0]["mean"], others[0]["stddev"], rasusa["mean"], rasusa["stddev"], with_stddev=False)

--- a/benches/update_readme.sh
+++ b/benches/update_readme.sh
@@ -44,6 +44,11 @@ fi
     exit 1
 }
 
+# Run benchmarked commands from CACHE_DIR and reference input FASTQs by basename, so the
+# rendered README table shows readable commands (`rasusa reads tb.fq ...`) instead of the
+# CI runner's full checkout path.
+cd "$CACHE_DIR"
+
 ### Single long-read input (rasusa vs filtlong) ###
 
 TB_FQ="$CACHE_DIR/tb.fq"
@@ -58,8 +63,9 @@ fi
 TB_GENOME_SIZE=4411532
 COVG=50
 TARGET_BASES=$((TB_GENOME_SIZE * COVG))
-FILTLONG_CMD="filtlong --target_bases $TARGET_BASES $TB_FQ"
-RASUSA_CMD="$RASUSA_BIN reads $TB_FQ -c $COVG -g $TB_GENOME_SIZE -s 1 -o /dev/null"
+TB_FQ_BASENAME="$(basename "$TB_FQ")"
+FILTLONG_CMD="filtlong --target_bases $TARGET_BASES $TB_FQ_BASENAME"
+RASUSA_CMD="$RASUSA_BIN reads $TB_FQ_BASENAME -c $COVG -g $TB_GENOME_SIZE -s 1 -o /dev/null"
 
 echo "[update_readme] running single-input benchmark..." >&2
 hyperfine --warmup 3 --runs 10 \
@@ -89,9 +95,11 @@ else
 fi
 
 NUM_READS=140000
-SEQTK_CMD_1="seqtk sample -s 1 $R1_FQ $NUM_READS > $WORK_DIR/o1.fq; seqtk sample -s 1 $R2_FQ $NUM_READS > $WORK_DIR/o2.fq;"
-SEQTK_CMD_2="seqtk sample -2 -s 1 $R1_FQ $NUM_READS > $WORK_DIR/o1.fq; seqtk sample -2 -s 1 $R2_FQ $NUM_READS > $WORK_DIR/o2.fq;"
-RASUSA_CMD="$RASUSA_BIN reads $R1_FQ $R2_FQ -n $NUM_READS -s 1 -o $WORK_DIR/o1.fq -o $WORK_DIR/o2.fq"
+R1_FQ_BASENAME="$(basename "$R1_FQ")"
+R2_FQ_BASENAME="$(basename "$R2_FQ")"
+SEQTK_CMD_1="seqtk sample -s 1 $R1_FQ_BASENAME $NUM_READS > $WORK_DIR/o1.fq; seqtk sample -s 1 $R2_FQ_BASENAME $NUM_READS > $WORK_DIR/o2.fq;"
+SEQTK_CMD_2="seqtk sample -2 -s 1 $R1_FQ_BASENAME $NUM_READS > $WORK_DIR/o1.fq; seqtk sample -2 -s 1 $R2_FQ_BASENAME $NUM_READS > $WORK_DIR/o2.fq;"
+RASUSA_CMD="$RASUSA_BIN reads $R1_FQ_BASENAME $R2_FQ_BASENAME -n $NUM_READS -s 1 -o $WORK_DIR/o1.fq -o $WORK_DIR/o2.fq"
 
 echo "[update_readme] running paired-input benchmark..." >&2
 hyperfine --warmup 10 --runs 100 \


### PR DESCRIPTION
## Summary
Found while confirming the just-fixed `benchmark.yaml` workflow's first successful run (see #205): the tables it committed to `README.md` are internally self-contradictory. The `Relative` column correctly shows `rasusa` at 52.17x and 1.46x/1.13x faster than the competitors, but the generated **Summary** sentences say the opposite (`ran 0.02 ± 0.00 times faster than filtlong`, `0.77`/`0.68` for the paired case).

Root cause: `benches/render_readme.py` identified which hyperfine result was the `rasusa` one via `"rasusa" in r["command"]`. On CI this always false-positives, because the repo (and so the checkout path, `/home/runner/work/rasusa/rasusa/...`) is itself named `rasusa` - every command's file arguments contain that substring, including `filtlong`'s and `seqtk`'s. The `next(...)` picked whichever result happened to match first, silently treating the wrong result as "rasusa" and inverting the ratio.

Fixed to match structurally (`(?:^|/)rasusa (reads|aln)\b` - executable named `rasusa` followed by a subcommand) instead of a bare substring, which can't collide with argument paths.

Also cleaned up a readability issue found alongside it: `update_readme.sh` now `cd`s into the download cache dir and references input FASTQs by basename in the benchmarked command strings, so the rendered README shows `rasusa reads tb.fq ...` instead of the full CI checkout path.

## Test plan
- [x] Unit-verified the new `_is_rasusa_cmd` matcher against the exact real command strings from the live (buggy) run, including the collision case - all correctly classified
- [x] Fed the real hyperfine numbers from the live run through `render_readme.py single-block`/`paired-block` directly - now prints the correct `52.13x`/`1.46x`/`1.13x` summaries matching the table
- [x] `cargo test --all-targets`, `just lint`, `cargo fmt --check` all clean
- [ ] Will re-trigger `benchmark.yaml` after merge for a fully correct live regeneration (current `README.md` on `main` still has the wrong summary sentences from before this fix)