### PR TITLE
deps(deps): bump noodles and noodles-util together

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,10 +121,11 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+checksum = "5727b15fa97d4f4fee0a3b7c3d550ed0269f54329207b86388de918604e31269"
 dependencies = [
+ "borsh",
  "serde",
 ]
 
@@ -147,6 +148,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -239,6 +264,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -889,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.112.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87594797cd9d328464328804fa8fc8921000b7b7c496a8225aeb86920d591258"
+checksum = "03f0a067d8afc481ba06abe5bd924e89368932d664bea15d671bee3559728421"
 dependencies = [
  "noodles-bam",
  "noodles-core",
@@ -901,29 +932,17 @@ dependencies = [
 
 [[package]]
 name = "noodles-bam"
-version = "0.91.0"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68aa8af90e253005bbb957a589da61d8966ea1453bb3c1122d53704ddaa5e93c"
+checksum = "6e70c87dfebe1800c6a59f1b4fc9e6d69e165876c2d475b2b684862a06225a70"
 dependencies = [
  "bstr",
  "indexmap",
  "memchr",
- "noodles-bgzf 0.48.0",
+ "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
  "noodles-sam",
-]
-
-[[package]]
-name = "noodles-bgzf"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1dbf501b46281ca402b458211653bc8c510ea605400a1192d272a35360aa54"
-dependencies = [
- "bytes",
- "crossbeam-channel",
- "rayon",
- "zlib-rs",
 ]
 
 [[package]]
@@ -950,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-cram"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9407d6f0ff87b1d7ee255ccf803bf1ef4917fc99605427ceb357ef2803749146"
+checksum = "992ab41d893cc19b8d04ea7c6d97af03c12b23f9294b022bc312eed7640ede3c"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -970,55 +989,55 @@ dependencies = [
 
 [[package]]
 name = "noodles-csi"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d2b47cd56d466c6b39d7d2d3f19905c786d5bbcf45c782af3c206129bb39b8"
+checksum = "b522467eb7ae4a226b05182069e895940beda9206a3f4da9dd9395613ec9e5a8"
 dependencies = [
  "bit-vec",
  "bstr",
  "indexmap",
- "noodles-bgzf 0.48.0",
+ "noodles-bgzf",
  "noodles-core",
 ]
 
 [[package]]
 name = "noodles-fasta"
-version = "0.63.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c4aa8074808f9ce83f52c8b3c0e832335b49d51bb6c99934e72549318a083b"
+checksum = "e057dee8e62fe97d0f0205e6865568fca380b6017d98f7c8a7740a17fa28c654"
 dependencies = [
  "bstr",
  "memchr",
- "noodles-bgzf 0.48.0",
+ "noodles-bgzf",
  "noodles-core",
 ]
 
 [[package]]
 name = "noodles-sam"
-version = "0.86.0"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2553a62c2a78d87686005327f2597a765ae55e10e2fd09015a54c0337676fbae"
+checksum = "db484fde243408e8713278e6e83dbd67765cbd33612f2383f29b6359059d023f"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
  "indexmap",
  "lexical-core",
  "memchr",
- "noodles-bgzf 0.48.0",
+ "noodles-bgzf",
  "noodles-core",
  "noodles-csi",
 ]
 
 [[package]]
 name = "noodles-util"
-version = "0.81.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f028edc299f70369aa0f6a00a6b6307560f0d82a573a26ad49cd0a36c62c4"
+checksum = "567c9ce0176a2c82097de4ea27c4da7395de0447f8df0369d6dfd99c9afdc788"
 dependencies = [
  "bstr",
  "flate2",
  "noodles-bam",
- "noodles-bgzf 0.48.0",
+ "noodles-bgzf",
  "noodles-core",
  "noodles-cram",
  "noodles-csi",
@@ -1155,6 +1174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,7 +1245,7 @@ dependencies = [
  "needletail",
  "niffler",
  "noodles",
- "noodles-bgzf 0.49.0",
+ "noodles-bgzf",
  "noodles-util",
  "predicates",
  "rand",
@@ -1482,6 +1510,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1675,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ rand_pcg = "0.10.1"
 log = "0.4"
 niffler = "2.5"
 env_logger = "0.11.9"
-noodles-util = { version = "0.81.0", features = ["alignment"] }
-noodles = { version = "0.112.0", features = ["bam", "cram", "core", "sam"] }
+noodles-util = { version = "0.82.0", features = ["alignment"] }
+noodles = { version = "0.113.0", features = ["bam", "cram", "core", "sam"] }
 noodles-bgzf = { version = "0.49.0", features = ["libdeflate"] }
 rustc-hash = "2.1"
 rayon = "1.10"


### PR DESCRIPTION
## Summary
- Bumps `noodles` 0.112.0 → 0.113.0 and `noodles-util` 0.81.0 → 0.82.0 together (also pulls `noodles-bam`/`noodles-sam`/etc. transitively into alignment).
- Dependabot opened #215 (`noodles-util` only) and #216 (`noodles` only) independently. Both `noodles` and `noodles-util` transitively depend on `noodles-sam`/`noodles-bam`, so bumping only one leaves two semver-incompatible copies of those crates in the lockfile — CI on both PRs fails with `expected noodles::noodles_sam::Header, found noodles_sam::header::Header` type mismatches in `src/alignment/fetch.rs`.
- Bumping both together lets cargo's resolver converge on a single shared `noodles-sam`/`noodles-bam` version, which builds and tests cleanly.

Closes #215
Closes #216

## Test plan
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo test --all-features` passes (34 tests, incl. reproducibility suite)